### PR TITLE
Fix test rename convertISODateToDate to convertFromISODateString

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -17,10 +17,10 @@ describe("utiilities", () => {
     });
   });
 
-  describe("convertISODateToDate", () => {
+  describe("convertFromISODateString", () => {
     it("Converts an ISO formatted date string to a JS date object", () => {
       let date = "2015-12-30";
-      expect(utils.convertISODateToDate(date).getTime()).to.equal(
+      expect(utils.convertFromISODateString(date).getTime()).to.equal(
         Date.parse(date)
       );
     });


### PR DESCRIPTION
This test was failing for me because it looks like the util got renamed from `convertISODateToDate` to `convertFromISODateString`.

<img width="403" alt="screen shot 2017-12-04 at 3 24 21 pm" src="https://user-images.githubusercontent.com/99604/33581818-3af56c76-d907-11e7-97d6-ec3e4cb3a42c.png">
