### PR TITLE
Default to 2 decimal digits when omitted from convertMilliUnitsToCurrencyAmount

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,34 +1,37 @@
 export class Utils {
-    /**
-     * Returns the current month (system timezone) in ISO 8601 format (i.e. '2015-12-01')
-     */
-    public getCurrentMonthInISOFormat() {
-        let currentDate = new Date();
-        let isoLocalDateString = new Date(
-            currentDate.getTime() - currentDate.getTimezoneOffset() * 60000
-        ).toISOString();
-        let isoFirstDayOfCurrentMonth = `${isoLocalDateString.substr(0, 7)}-01`;
-        return isoFirstDayOfCurrentMonth;
-    }
+  /**
+   * Returns the current month (system timezone) in ISO 8601 format (i.e. '2015-12-01')
+   */
+  public getCurrentMonthInISOFormat() {
+    let currentDate = new Date();
+    let isoLocalDateString = new Date(
+      currentDate.getTime() - currentDate.getTimezoneOffset() * 60000
+    ).toISOString();
+    let isoFirstDayOfCurrentMonth = `${isoLocalDateString.substr(0, 7)}-01`;
+    return isoFirstDayOfCurrentMonth;
+  }
 
-    /**
-     * Converts an ISO 8601 formatted string to a JS date object
-     * @param {string} isoDateString - An ISO 8601 formatted date (i.e. '2015-12-30').  This date is assumed to be in UTC timezone
-     */
-    public convertFromISODateString(isoDateString: string) {
-        return new Date(new Date(isoDateString));
-    }
+  /**
+   * Converts an ISO 8601 formatted string to a JS date object
+   * @param {string} isoDateString - An ISO 8601 formatted date (i.e. '2015-12-30').  This date is assumed to be in UTC timezone
+   */
+  public convertFromISODateString(isoDateString: string) {
+    return new Date(new Date(isoDateString));
+  }
 
-    /**
-     * Converts a milliunits amount to a currency amount
-     * @param milliunits - The milliunits amount (i.e. 293294)
-     * @param [currencyDecimalDigits] - The number of decimals in the currency (i.e. 2 for USD)
-     */
-    public convertMilliUnitsToCurrencyAmount(milliunits: number, currencyDecimalDigits: number = 2): number {
-        let numberToRoundTo = Math.pow(10, 3 - Math.min(3, currencyDecimalDigits));
-        numberToRoundTo = 1 / numberToRoundTo;
-        let rounded = Math.round(milliunits * numberToRoundTo) / numberToRoundTo;
-        let currencyAmount = rounded * (0.1 / Math.pow(10, 2));
-        return currencyAmount;
-    }
+  /**
+   * Converts a milliunits amount to a currency amount
+   * @param milliunits - The milliunits amount (i.e. 293294)
+   * @param [currencyDecimalDigits] - The number of decimals in the currency (i.e. 2 for USD)
+   */
+  public convertMilliUnitsToCurrencyAmount(
+    milliunits: number,
+    currencyDecimalDigits: number = 2
+  ): number {
+    let numberToRoundTo = Math.pow(10, 3 - Math.min(3, currencyDecimalDigits));
+    numberToRoundTo = 1 / numberToRoundTo;
+    let rounded = Math.round(milliunits * numberToRoundTo) / numberToRoundTo;
+    let currencyAmount = rounded * (0.1 / Math.pow(10, 2));
+    return currencyAmount;
+  }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -5,44 +5,56 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("utiilities", () => {
-    const utils = new Utils();
+  const utils = new Utils();
 
-    describe("getTodaysDateInISOFormat", () => {
-        it("Returns today's date in ISO format", () => {
-            let now = new Date();
-            let month = ("0" + (now.getMonth() + 1)).slice(-2);
-            let today = now.getFullYear() + "-" + month + "-01";
+  describe("getTodaysDateInISOFormat", () => {
+    it("Returns today's date in ISO format", () => {
+      let now = new Date();
+      let month = ("0" + (now.getMonth() + 1)).slice(-2);
+      let today = now.getFullYear() + "-" + month + "-01";
 
-            expect(utils.getCurrentMonthInISOFormat()).to.equal(today);
-        });
+      expect(utils.getCurrentMonthInISOFormat()).to.equal(today);
+    });
+  });
+
+  describe("convertFromISODateString", () => {
+    it("Converts an ISO formatted date string to a JS date object", () => {
+      let date = "2015-12-30";
+      expect(utils.convertFromISODateString(date).getTime()).to.equal(
+        Date.parse(date)
+      );
+    });
+  });
+
+  describe("convertMilliUnitsToCurrencyAmount", () => {
+    it("Converts millidolars to 2 decimimal currency", () => {
+      expect(utils.convertMilliUnitsToCurrencyAmount(239323, 2)).to.equal(
+        239.32
+      );
     });
 
-    describe("convertFromISODateString", () => {
-        it("Converts an ISO formatted date string to a JS date object", () => {
-            let date = "2015-12-30";
-            expect(utils.convertFromISODateString(date).getTime()).to.equal(Date.parse(date));
-        });
+    it("Rounds up", () => {
+      expect(utils.convertMilliUnitsToCurrencyAmount(239325, 2)).to.equal(
+        239.33
+      );
     });
 
-    describe("convertMilliUnitsToCurrencyAmount", () => {
-        it("Converts millidolars to 2 decimimal currency", () => {
-            expect(utils.convertMilliUnitsToCurrencyAmount(239323, 2)).to.equal(239.32);
-        });
-
-        it("Rounds up", () => {
-            expect(utils.convertMilliUnitsToCurrencyAmount(239325, 2)).to.equal(239.33);
-        });
-
-        it("Converts millidolars to 3 decimal currency", () => {
-            expect(utils.convertMilliUnitsToCurrencyAmount(239323, 3)).to.equal(239.323);
-        });
-
-        it("Converts millidolars to 0 decimal currency", () => {
-            expect(utils.convertMilliUnitsToCurrencyAmount(239323, 0)).to.equal(239);
-        });
-
-        it("Defaults to 2 decimal places when omitted", () => {
-            expect(utils.convertMilliUnitsToCurrencyAmount(239323)).to.equal(239.32);
-        });
+    it("Converts millidolars to 3 decimal currency", () => {
+      expect(utils.convertMilliUnitsToCurrencyAmount(239323, 3)).to.equal(
+        239.323
+      );
     });
+
+    it("Converts millidolars to 0 decimal currency", () => {
+      expect(utils.convertMilliUnitsToCurrencyAmount(239323, 0)).to.equal(
+        239
+      );
+    });
+
+    it("Defaults to 2 decimal places when omitted", () => {
+      expect(utils.convertMilliUnitsToCurrencyAmount(239323)).to.equal(
+        239.32
+      );
+    });
+  });
 });


### PR DESCRIPTION
I ran `ynab.utils.convertMilliUnitsToCurrencyAmount(transaction.amount)` and got `NaN`. I think a good default if that parameter is omitted would be `2` decimal digits.