### PR TITLE
Add export to google sheets example

### DIFF
--- a/examples/export-to-google-sheets/auth.js
+++ b/examples/export-to-google-sheets/auth.js
@@ -1,0 +1,67 @@
+/*
+ * This library provides a function "authorize" to generate an OAuth link for
+ * the Google Sheets API. After getting the code (in the redirect URL query string)
+ * paste it into the console prompt.
+ *
+ * It will then write the token into your home folder .credentials/ for subsequent
+ * API queries.
+ */
+const fs = require("fs");
+const readline = require("readline");
+const googleAuth = require("google-auth-library");
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+const TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE) + "/.credentials/";
+const TOKEN_PATH = TOKEN_DIR + "sheets.googleapis.com-ynab-example.json";
+
+module.exports = authorize;
+function authorize(secrets, cb) {
+    const clientSecret = secrets.google.client_secret;
+    const clientId = secrets.google.client_id;
+    const redirectUrl = secrets.google.redirect_url;
+    const auth = new googleAuth();
+    const oauth2Client = new auth.OAuth2(clientId, clientSecret, redirectUrl);
+    fs.readFile(TOKEN_PATH, function(err, token) {
+        if (err) {
+            getNewToken(oauth2Client, cb);
+        } else {
+            oauth2Client.credentials = JSON.parse(token);
+            cb(oauth2Client);
+        }
+    });
+}
+
+function getNewToken(oauth2Client, callback) {
+    var authUrl = oauth2Client.generateAuthUrl({
+        access_type: "offline",
+        scope: SCOPES
+    });
+    console.log("Authorize this app by visiting this url: ", authUrl);
+    var rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+    rl.question("Enter the code from that page here: ", function(code) {
+        rl.close();
+        oauth2Client.getToken(code, function(err, token) {
+            if (err) {
+                console.log("Error while trying to retrieve access token", err);
+                return;
+            }
+            oauth2Client.credentials = token;
+            storeToken(token);
+            callback(oauth2Client);
+        });
+    });
+}
+
+function storeToken(token) {
+    try {
+        fs.mkdirSync(TOKEN_DIR);
+    } catch (err) {
+        if (err.code != "EEXIST") {
+            throw err;
+        }
+    }
+    fs.writeFile(TOKEN_PATH, JSON.stringify(token), function() {});
+    console.log("Token stored to " + TOKEN_PATH);
+}

--- a/examples/export-to-google-sheets/index.js
+++ b/examples/export-to-google-sheets/index.js
@@ -1,0 +1,96 @@
+const YNAB = require("ynab");
+const google = require("googleapis");
+const authorize = require("./auth");
+const secrets = require("./secrets.json");
+
+// Your YNAB Budget ID
+const BUDGET_ID = "[BUDGET_ID HERE]";
+// Your Google Sheet ID
+const SPREADSHEET_ID = "[SPREADSHEET_ID HERE]";
+// Which sheet and cell to append to
+const RANGE = "Sheet!A1";
+
+// Initialize the YNAB API
+const ynab = new YNAB(secrets.ynab);
+
+// Our main entry point to this script
+// Gathers transactions from YNAB and appends them to a Google Sheet
+function main(auth) {
+    const sheets = google.sheets("v4");
+    getTransactions().then(function (values) {
+        sheets.spreadsheets.values.append(
+            {
+                auth: auth,
+                spreadsheetId: SPREADSHEET_ID,
+                valueInputOption: "USER_ENTERED",
+                resource: { values: values },
+                range: RANGE
+            },
+            function(err, response) {
+                if (err) {
+                    console.log("The API returned an error: " + err);
+                    return;
+                }
+                console.log(response.updatedCells + " cells updated.");
+            }
+        );
+    });
+}
+
+// Authorize with Google and then run the "main" function
+authorize(secrets, main);
+
+// Gets transactions from YNAB and then transforms them into cell data
+function getTransactions() {
+    return Promise.all([
+        ynab.categories.getCategories(BUDGET_ID),
+        ynab.accounts.getAccounts(BUDGET_ID),
+        ynab.payees.getPayees(BUDGET_ID),
+        ynab.transactions.getTransactions(BUDGET_ID)
+    ]).then(function (results) {
+        const category_groups = results[0].data.category_groups;
+        const accounts = results[1].data.accounts;
+        const payees = results[2].data.payees;
+        const transactions = results[3].data.transactions;
+
+        // Build maps of categories, accounts and payees to more easily map
+        // the ids when iterating the transactions
+
+        const categoriesMap = {};
+        category_groups.forEach(function (group) {
+            group.categories.forEach(function (sub) {
+                categoriesMap[sub.id] = {
+                    id: sub.id,
+                    name: group.name + ": " + sub.name,
+                    hidden: sub.hidden
+                };
+            });
+        });
+
+        const accountsMap = {};
+        accounts.forEach(function (account) {
+            accountsMap[account.id] = account;
+        });
+
+        const payeesMap = {};
+        payees.forEach(function (payee) {
+            payeesMap[payee.id] = payee;
+        });
+
+        const result = transactions.map(function (transaction) {
+            const account = accountsMap[transaction.account_id];
+            const payee = payeesMap[transaction.payee_id];
+            const category = categoriesMap[transaction.category_id];
+            return [
+                transaction.date,
+                ynab.utils.convertMilliUnitsToCurrencyAmount(transaction.amount, 2),
+                account ? account.name : "",
+                payee ? payee.name : "",
+                category ? category.name : "",
+                transaction.memo
+            ];
+        });
+        result.unshift(["date", "amount", "account", "payee", "category", "memo"]);
+        return result;
+    });
+}

--- a/examples/export-to-google-sheets/package.json
+++ b/examples/export-to-google-sheets/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "export-to-google-sheets",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "google-auth-library": "^0.12.0",
+    "googleapis": "^23.0.0",
+    "ynab": "^1.0.0"
+  }
+}

--- a/examples/export-to-google-sheets/secrets.json
+++ b/examples/export-to-google-sheets/secrets.json
@@ -1,0 +1,12 @@
+{
+    "ynab": "[YNAB API KEY HERE]",
+    "google": {
+        "client_id": "[GOOGLE client_id.json HERE AND BELOW]",
+        "project_id": "",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://accounts.google.com/o/oauth2/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_secret": "",
+        "redirect_url": ""
+    }
+}


### PR DESCRIPTION
I pulled this from an electron app I started over the break (sorry it's not in TS) that updates a Google Sheet daily so I can build custom reports.

But this will show people how to...
- Go through OAuth with the Google Sheets API
- Grab and map accounts, categories and payees to all their YNAB transactions
- Append all their transactions to a Google Sheet

---

I have some improvements planned to make it only download new transactions from YNAB and handle duplicates in the spreadsheet. But wanted to see if there was any interest in adding this example and whether I should update it to use TS for consistency with other examples.