### PR TITLE
Implement support for transaction create/update/bulk create

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,13 @@ with [ISO dates and milliunits](https://api.youneedabudget.com/#formats) a bit
 easier.
 
 ```typescript
-/**
-  * Returns the current month (system timezone) in ISO 8601 format (i.e. '2015-12-01')
-  */
+// Returns the current month (system timezone) in ISO 8601 format (i.e. '2015-12-01')
 getCurrentMonthInISOFormat(): string;
-
-/**
-  * Converts an ISO 8601 formatted string to a JS date object
-  * @param {string} isoDate - An ISO 8601 formatted date (i.e. '2015-12-30').  This date is assumed to be in UTC timezone
-  */
+// Returns the current date (system timezone) in ISO 8601 format (i.e. '2015-12-15')
+getCurrentDateInISOFormat(): string;
+// Converts an ISO 8601 formatted string to a JS date object
 convertFromISODateString(isoDateString: string): Date;
-
-/**
- * Converts a milliunits amount to a currency amount
- * @param milliunits - The milliunits amount (i.e. 293294)
- * @param currencyDecimalDigits - The number of decimals in the currency (i.e. 2 for USD)
- */
+// Converts a milliunits amount to a currency amount
 convertMilliUnitsToCurrencyAmount(milliunits: number, currencyDecimalDigits: number): number;
 ```
 

--- a/build/swagger-config-typescript.json
+++ b/build/swagger-config-typescript.json
@@ -1,5 +1,5 @@
 {
   "npmName": "ynab",
-  "npmVersion": "0.1.2",
+  "npmVersion": "0.2.1",
   "supportsES6": true
 }

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -261,6 +261,45 @@ export interface BudgetSummaryWrapper {
 /**
  *
  * @export
+ * @interface BulkTransactionCreateResponse
+ */
+export interface BulkTransactionCreateResponse {
+    /**
+     *
+     * @type {BulkTransactionIds}
+     * @memberof BulkTransactionCreateResponse
+     */
+    data: BulkTransactionIds;
+}
+/**
+ *
+ * @export
+ * @interface BulkTransactionIds
+ */
+export interface BulkTransactionIds {
+    /**
+     *
+     * @type {Array&lt;string&gt;}
+     * @memberof BulkTransactionIds
+     */
+    transaction_ids: Array<string>;
+}
+/**
+ *
+ * @export
+ * @interface BulkTransactions
+ */
+export interface BulkTransactions {
+    /**
+     *
+     * @type {Array&lt;SaveTransaction&gt;}
+     * @memberof BulkTransactions
+     */
+    transactions: Array<SaveTransaction>;
+}
+/**
+ *
+ * @export
  * @interface CategoriesResponse
  */
 export interface CategoriesResponse {
@@ -696,6 +735,76 @@ export interface PayeesWrapper {
      * @memberof PayeesWrapper
      */
     payees: Array<Payee>;
+}
+/**
+ *
+ * @export
+ * @interface SaveTransaction
+ */
+export interface SaveTransaction {
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    account_id: string;
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    date: string;
+    /**
+     * The transaction amount in milliunits format
+     * @type {number}
+     * @memberof SaveTransaction
+     */
+    amount: number;
+    /**
+     * The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    payee_id?: string;
+    /**
+     * The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    category_id?: string;
+    /**
+     * The cleared status of the transaction
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    cleared?: SaveTransaction.ClearedEnum;
+    /**
+     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
+     * @type {boolean}
+     * @memberof SaveTransaction
+     */
+    approved?: boolean;
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    memo?: string;
+}
+/**
+ * @export
+ * @namespace SaveTransaction
+ */
+export declare namespace SaveTransaction {
+    /**
+     * @export
+     * @enum {string}
+     */
+    enum ClearedEnum {
+        Cleared,
+        Uncleared,
+        Reconciled,
+    }
 }
 /**
  *
@@ -1810,30 +1919,39 @@ export declare class ScheduledTransactionsApi extends BaseAPI {
  * @export
  */
 export declare const TransactionsApiFetchParamCreator: (configuration?: Configuration) => {
+    bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any): FetchArgs;
+    createTransaction(budget_id: string, transaction: SaveTransaction, options?: any): FetchArgs;
     getTransactions(budget_id: string, since_date?: string | Date, type?: string, options?: any): FetchArgs;
     getTransactionsByAccount(budget_id: string, account_id: string, since_date?: string | Date, options?: any): FetchArgs;
     getTransactionsByCategory(budget_id: string, category_id: string, since_date?: string | Date, options?: any): FetchArgs;
     getTransactionsById(budget_id: string, transaction_id: string, options?: any): FetchArgs;
+    updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any): FetchArgs;
 };
 /**
  * TransactionsApi - functional programming interface
  * @export
  */
 export declare const TransactionsApiFp: (configuration?: Configuration) => {
+    bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any): (fetchFunction?: FetchAPI) => Promise<BulkTransactionCreateResponse>;
+    createTransaction(budget_id: string, transaction: SaveTransaction, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse>;
     getTransactions(budget_id: string, since_date?: string | Date, type?: string, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionsResponse>;
     getTransactionsByAccount(budget_id: string, account_id: string, since_date?: string | Date, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionsResponse>;
     getTransactionsByCategory(budget_id: string, category_id: string, since_date?: string | Date, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionsResponse>;
     getTransactionsById(budget_id: string, transaction_id: string, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse>;
+    updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse>;
 };
 /**
  * TransactionsApi - factory interface
  * @export
  */
 export declare const TransactionsApiFactory: (configuration?: Configuration) => {
+    bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any): Promise<BulkTransactionCreateResponse>;
+    createTransaction(budget_id: string, transaction: SaveTransaction, options?: any): Promise<TransactionResponse>;
     getTransactions(budget_id: string, since_date?: string | Date, type?: string, options?: any): Promise<TransactionsResponse>;
     getTransactionsByAccount(budget_id: string, account_id: string, since_date?: string | Date, options?: any): Promise<TransactionsResponse>;
     getTransactionsByCategory(budget_id: string, category_id: string, since_date?: string | Date, options?: any): Promise<TransactionsResponse>;
     getTransactionsById(budget_id: string, transaction_id: string, options?: any): Promise<TransactionResponse>;
+    updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any): Promise<TransactionResponse>;
 };
 /**
  * TransactionsApi - object-oriented interface
@@ -1842,6 +1960,26 @@ export declare const TransactionsApiFactory: (configuration?: Configuration) => 
  * @extends {BaseAPI}
  */
 export declare class TransactionsApi extends BaseAPI {
+    /**
+     * Creates multiple transactions
+     * @summary Bulk create transactions
+     * @param {string} budget_id - ID of budget
+     * @param {BulkTransactions} transactions - Transactions to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any): Promise<BulkTransactionCreateResponse>;
+    /**
+     * Creates a transaction
+     * @summary Create new transaction
+     * @param {string} budget_id - ID of budget
+     * @param {SaveTransaction} transaction - Transaction to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    createTransaction(budget_id: string, transaction: SaveTransaction, options?: any): Promise<TransactionResponse>;
     /**
      * Returns budget transactions
      * @summary List transactions
@@ -1885,4 +2023,15 @@ export declare class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     getTransactionsById(budget_id: string, transaction_id: string, options?: any): Promise<TransactionResponse>;
+    /**
+     * Updates a transaction
+     * @summary Updates an existing transaction
+     * @param {string} budget_id - ID of budget
+     * @param {string} transaction_id - ID of transaction
+     * @param {SaveTransaction} transaction - Transaction to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any): Promise<TransactionResponse>;
 }

--- a/dist/api.js
+++ b/dist/api.js
@@ -17,7 +17,7 @@ const url = require("url");
 // Requiring portable-fetch like this ensures that we have a global fetch function
 // That makes it easier to override with modules like fetch-mock
 require("portable-fetch");
-const USER_AGENT = "api_client/js/0.1.2";
+const USER_AGENT = "api_client/js/0.2.1";
 function convertDateToFullDateStringFormat(date) {
     // Convert to RFC 3339 "full-date" format, like "2017-11-27"
     if (date instanceof Date) {
@@ -81,6 +81,23 @@ var Account;
         TypeEnum[TypeEnum["CreditCard"] = 'CreditCard'] = "CreditCard";
     })(TypeEnum = Account.TypeEnum || (Account.TypeEnum = {}));
 })(Account = exports.Account || (exports.Account = {}));
+/**
+ * @export
+ * @namespace SaveTransaction
+ */
+var SaveTransaction;
+(function (SaveTransaction) {
+    /**
+     * @export
+     * @enum {string}
+     */
+    let ClearedEnum;
+    (function (ClearedEnum) {
+        ClearedEnum[ClearedEnum["Cleared"] = 'Cleared'] = "Cleared";
+        ClearedEnum[ClearedEnum["Uncleared"] = 'Uncleared'] = "Uncleared";
+        ClearedEnum[ClearedEnum["Reconciled"] = 'Reconciled'] = "Reconciled";
+    })(ClearedEnum = SaveTransaction.ClearedEnum || (SaveTransaction.ClearedEnum = {}));
+})(SaveTransaction = exports.SaveTransaction || (exports.SaveTransaction = {}));
 /**
  * @export
  * @namespace ScheduledTransactionSummary
@@ -1653,6 +1670,92 @@ exports.ScheduledTransactionsApi = ScheduledTransactionsApi;
 exports.TransactionsApiFetchParamCreator = function (configuration) {
     return {
         /**
+         * Creates multiple transactions
+         * @summary Bulk create transactions
+         * @param {string} budget_id - ID of budget
+         * @param {BulkTransactions} transactions - Transactions to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        bulkCreateTransactions(budget_id, transactions, options = {}) {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id', 'Required parameter budget_id was null or undefined when calling bulkCreateTransactions.');
+            }
+            // verify required parameter 'transactions' is not null or undefined
+            if (transactions === null || transactions === undefined) {
+                throw new RequiredError('transactions', 'Required parameter transactions was null or undefined when calling bulkCreateTransactions.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions/bulk`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {};
+            const localVarQueryParameter = {};
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            localVarRequestOptions.body = JSON.stringify(transactions || {});
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Creates a transaction
+         * @summary Create new transaction
+         * @param {string} budget_id - ID of budget
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        createTransaction(budget_id, transaction, options = {}) {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id', 'Required parameter budget_id was null or undefined when calling createTransaction.');
+            }
+            // verify required parameter 'transaction' is not null or undefined
+            if (transaction === null || transaction === undefined) {
+                throw new RequiredError('transaction', 'Required parameter transaction was null or undefined when calling createTransaction.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {};
+            const localVarQueryParameter = {};
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            localVarRequestOptions.body = JSON.stringify(transaction || {});
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Returns budget transactions
          * @summary List transactions
          * @param {string} budget_id - ID of budget
@@ -1830,6 +1933,55 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Updates a transaction
+         * @summary Updates an existing transaction
+         * @param {string} budget_id - ID of budget
+         * @param {string} transaction_id - ID of transaction
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        updateTransaction(budget_id, transaction_id, transaction, options = {}) {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id', 'Required parameter budget_id was null or undefined when calling updateTransaction.');
+            }
+            // verify required parameter 'transaction_id' is not null or undefined
+            if (transaction_id === null || transaction_id === undefined) {
+                throw new RequiredError('transaction_id', 'Required parameter transaction_id was null or undefined when calling updateTransaction.');
+            }
+            // verify required parameter 'transaction' is not null or undefined
+            if (transaction === null || transaction === undefined) {
+                throw new RequiredError('transaction', 'Required parameter transaction was null or undefined when calling updateTransaction.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
+                .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'PUT' }, options);
+            const localVarHeaderParameter = {};
+            const localVarQueryParameter = {};
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            localVarRequestOptions.body = JSON.stringify(transaction || {});
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     };
 };
 /**
@@ -1838,6 +1990,52 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
  */
 exports.TransactionsApiFp = function (configuration) {
     return {
+        /**
+         * Creates multiple transactions
+         * @summary Bulk create transactions
+         * @param {string} budget_id - ID of budget
+         * @param {BulkTransactions} transactions - Transactions to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        bulkCreateTransactions(budget_id, transactions, options) {
+            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).bulkCreateTransactions(budget_id, transactions, options);
+            return (fetchFunction = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    }
+                    else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
+        /**
+         * Creates a transaction
+         * @summary Create new transaction
+         * @param {string} budget_id - ID of budget
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        createTransaction(budget_id, transaction, options) {
+            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).createTransaction(budget_id, transaction, options);
+            return (fetchFunction = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    }
+                    else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
         /**
          * Returns budget transactions
          * @summary List transactions
@@ -1933,6 +2131,30 @@ exports.TransactionsApiFp = function (configuration) {
                 });
             };
         },
+        /**
+         * Updates a transaction
+         * @summary Updates an existing transaction
+         * @param {string} budget_id - ID of budget
+         * @param {string} transaction_id - ID of transaction
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        updateTransaction(budget_id, transaction_id, transaction, options) {
+            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).updateTransaction(budget_id, transaction_id, transaction, options);
+            return (fetchFunction = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    }
+                    else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
     };
 };
 /**
@@ -1941,6 +2163,28 @@ exports.TransactionsApiFp = function (configuration) {
  */
 exports.TransactionsApiFactory = function (configuration) {
     return {
+        /**
+         * Creates multiple transactions
+         * @summary Bulk create transactions
+         * @param {string} budget_id - ID of budget
+         * @param {BulkTransactions} transactions - Transactions to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        bulkCreateTransactions(budget_id, transactions, options) {
+            return exports.TransactionsApiFp(configuration).bulkCreateTransactions(budget_id, transactions, options)();
+        },
+        /**
+         * Creates a transaction
+         * @summary Create new transaction
+         * @param {string} budget_id - ID of budget
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        createTransaction(budget_id, transaction, options) {
+            return exports.TransactionsApiFp(configuration).createTransaction(budget_id, transaction, options)();
+        },
         /**
          * Returns budget transactions
          * @summary List transactions
@@ -1988,6 +2232,18 @@ exports.TransactionsApiFactory = function (configuration) {
         getTransactionsById(budget_id, transaction_id, options) {
             return exports.TransactionsApiFp(configuration).getTransactionsById(budget_id, transaction_id, options)();
         },
+        /**
+         * Updates a transaction
+         * @summary Updates an existing transaction
+         * @param {string} budget_id - ID of budget
+         * @param {string} transaction_id - ID of transaction
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        updateTransaction(budget_id, transaction_id, transaction, options) {
+            return exports.TransactionsApiFp(configuration).updateTransaction(budget_id, transaction_id, transaction, options)();
+        },
     };
 };
 /**
@@ -1997,6 +2253,30 @@ exports.TransactionsApiFactory = function (configuration) {
  * @extends {BaseAPI}
  */
 class TransactionsApi extends BaseAPI {
+    /**
+     * Creates multiple transactions
+     * @summary Bulk create transactions
+     * @param {string} budget_id - ID of budget
+     * @param {BulkTransactions} transactions - Transactions to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    bulkCreateTransactions(budget_id, transactions, options) {
+        return exports.TransactionsApiFp(this.configuration).bulkCreateTransactions(budget_id, transactions, options)();
+    }
+    /**
+     * Creates a transaction
+     * @summary Create new transaction
+     * @param {string} budget_id - ID of budget
+     * @param {SaveTransaction} transaction - Transaction to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    createTransaction(budget_id, transaction, options) {
+        return exports.TransactionsApiFp(this.configuration).createTransaction(budget_id, transaction, options)();
+    }
     /**
      * Returns budget transactions
      * @summary List transactions
@@ -2047,6 +2327,19 @@ class TransactionsApi extends BaseAPI {
      */
     getTransactionsById(budget_id, transaction_id, options) {
         return exports.TransactionsApiFp(this.configuration).getTransactionsById(budget_id, transaction_id, options)();
+    }
+    /**
+     * Updates a transaction
+     * @summary Updates an existing transaction
+     * @param {string} budget_id - ID of budget
+     * @param {string} transaction_id - ID of transaction
+     * @param {SaveTransaction} transaction - Transaction to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    updateTransaction(budget_id, transaction_id, transaction, options) {
+        return exports.TransactionsApiFp(this.configuration).updateTransaction(budget_id, transaction_id, transaction, options)();
     }
 }
 exports.TransactionsApi = TransactionsApi;

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -4,6 +4,10 @@ export declare class Utils {
      */
     getCurrentMonthInISOFormat(): string;
     /**
+     * Returns the current date (system timezone) in ISO 8601 format (i.e. '2015-12-15')
+     */
+    getCurrentDateInISOFormat(): string;
+    /**
      * Converts an ISO 8601 formatted string to a JS date object
      * @param {string} isoDateString - An ISO 8601 formatted date (i.e. '2015-12-30').  This date is assumed to be in UTC timezone
      */

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -5,10 +5,15 @@ class Utils {
      * Returns the current month (system timezone) in ISO 8601 format (i.e. '2015-12-01')
      */
     getCurrentMonthInISOFormat() {
+        return `${this.getCurrentDateInISOFormat().substr(0, 7)}-01`;
+    }
+    /**
+     * Returns the current date (system timezone) in ISO 8601 format (i.e. '2015-12-15')
+     */
+    getCurrentDateInISOFormat() {
         let currentDate = new Date();
         let isoLocalDateString = new Date(currentDate.getTime() - currentDate.getTimezoneOffset() * 60000).toISOString();
-        let isoFirstDayOfCurrentMonth = `${isoLocalDateString.substr(0, 7)}-01`;
-        return isoFirstDayOfCurrentMonth;
+        return isoLocalDateString;
     }
     /**
      * Converts an ISO 8601 formatted string to a JS date object

--- a/examples/bulk-transaction-create/index.js
+++ b/examples/bulk-transaction-create/index.js
@@ -1,0 +1,49 @@
+Object.defineProperty(exports, "__esModule", { value: true });
+const ynabApi = require("../../dist/index.js");
+const yargs = require("yargs");
+const api_1 = require("../../dist/api");
+const argv = yargs
+    .env("YNAB_API")
+    .option("accessToken", { alias: "access_token" }).argv;
+// You can get your API key from the My Account section of YNAB
+if (!argv.accessToken) {
+    console.warn(`
+'access_token' argument is required!  You can pass it in one of the following ways:
+  --access_token=123 CLI argument
+  YNAB_API_ACCESS_TOKEN environment variable
+`);
+    process.exit(1);
+}
+const ynab = new ynabApi(argv.accessToken);
+const bulkTransactions = {
+    transactions: [
+        {
+            account_id: "fc863acf-9e34-4908-9e86-c94b93b2296a",
+            date: ynab.utils.getCurrentDateInISOFormat(),
+            amount: -50000,
+            memo: "Refund for Kitchen Supplies"
+        },
+        {
+            account_id: "fc863acf-9e34-4908-9e86-c94b93b2296a",
+            category_id: "75655c30-ab05-4533-ae4b-8d958e02e73c",
+            payee_id: "c8aaf97d-eca5-4d5e-a583-e4043758f953",
+            cleared: api_1.SaveTransaction.ClearedEnum.Cleared,
+            approved: true,
+            date: ynab.utils.getCurrentDateInISOFormat(),
+            amount: -23430,
+            memo: "Dry Cleaning"
+        },
+        {
+            account_id: "fc863acf-9e34-4908-9e86-c94b93b2296a",
+            category_id: "3e0de9e2-b2eb-462d-bc71-a77a864d2d3b",
+            date: ynab.utils.getCurrentDateInISOFormat(),
+            amount: 1000000,
+            memo: "Income"
+        }
+    ]
+};
+ynab.transactions
+    .bulkCreateTransactions("26e3d088-8004-4785-9059-fd609b2f4642", bulkTransactions)
+    .catch(e => {
+    console.log(`ERROR: ${JSON.stringify(e)}`);
+});

--- a/examples/bulk-transaction-create/index.ts
+++ b/examples/bulk-transaction-create/index.ts
@@ -1,0 +1,55 @@
+import ynabApi = require("../../dist/index.js");
+import * as yargs from "yargs";
+import { BulkTransactions, SaveTransaction } from "../../dist/api";
+
+const argv = yargs
+  .env("YNAB_API")
+  .option("accessToken", { alias: "access_token" }).argv;
+// You can get your API key from the My Account section of YNAB
+if (!argv.accessToken) {
+  console.warn(`
+'access_token' argument is required!  You can pass it in one of the following ways:
+  --access_token=123 CLI argument
+  YNAB_API_ACCESS_TOKEN environment variable
+`);
+  process.exit(1);
+}
+
+const ynab = new ynabApi(argv.accessToken);
+
+const bulkTransactions: BulkTransactions = {
+  transactions: [
+    {
+      account_id: "fc863acf-9e34-4908-9e86-c94b93b2296a",
+      date: ynab.utils.getCurrentDateInISOFormat(),
+      amount: -50000,
+      memo: "Refund for Kitchen Supplies"
+    },
+    {
+      account_id: "fc863acf-9e34-4908-9e86-c94b93b2296a",
+      category_id: "75655c30-ab05-4533-ae4b-8d958e02e73c",
+      payee_id: "c8aaf97d-eca5-4d5e-a583-e4043758f953",
+      cleared: SaveTransaction.ClearedEnum.Cleared,
+      approved: true,
+      date: ynab.utils.getCurrentDateInISOFormat(),
+      amount: -23430,
+      memo: "Dry Cleaning"
+    },
+    {
+      account_id: "fc863acf-9e34-4908-9e86-c94b93b2296a",
+      category_id: "3e0de9e2-b2eb-462d-bc71-a77a864d2d3b",
+      date: ynab.utils.getCurrentDateInISOFormat(),
+      amount: 1000000,
+      memo: "Income"
+    }
+  ]
+};
+
+ynab.transactions
+  .bulkCreateTransactions(
+    "26e3d088-8004-4785-9059-fd609b2f4642",
+    bulkTransactions
+  )
+  .catch(e => {
+    console.log(`ERROR: ${JSON.stringify(e)}`);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -642,9 +642,9 @@
       }
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
       "dev": true
     },
     "pseudomap": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.4",
     "mocha": "^4.0.1",
     "moment": "^2.19.2",
-    "prettier": "1.8.2",
+    "prettier": "^1.10.2",
     "swagger-model-validator": "^2.2.1",
     "ts-node": "^3.3.0",
     "typescript": "^2.6",

--- a/spec-v1-swagger.json
+++ b/spec-v1-swagger.json
@@ -660,6 +660,88 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": ["Transactions"],
+        "summary": "Create new transaction",
+        "description": "Creates a transaction",
+        "operationId": "createTransaction",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "budget_id",
+            "in": "path",
+            "description": "ID of budget",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "name": "transaction",
+            "in": "body",
+            "description": "Transaction to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SaveTransaction"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/TransactionResponse"
+            }
+          },
+          "400": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/budgets/{budget_id}/transactions/bulk": {
+      "post": {
+        "tags": ["Transactions"],
+        "summary": "Bulk create transactions",
+        "description": "Creates multiple transactions",
+        "operationId": "bulkCreateTransactions",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "budget_id",
+            "in": "path",
+            "description": "ID of budget",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "name": "transactions",
+            "in": "body",
+            "description": "Transactions to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BulkTransactions"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/BulkTransactionCreateResponse"
+            }
+          },
+          "400": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
       }
     },
     "/budgets/{budget_id}/accounts/{account_id}/transactions": {
@@ -811,6 +893,54 @@
             }
           },
           "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Transactions"],
+        "summary": "Updates an existing transaction",
+        "description": "Updates a transaction",
+        "operationId": "updateTransaction",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "budget_id",
+            "in": "path",
+            "description": "ID of budget",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "description": "ID of transaction",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "name": "transaction",
+            "in": "body",
+            "description": "Transaction to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SaveTransaction"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "schema": {
+              "$ref": "#/definitions/TransactionResponse"
+            }
+          },
+          "400": {
             "description": "Error",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
@@ -1529,6 +1659,80 @@
           }
         }
       ]
+    },
+    "SaveTransaction": {
+      "type": "object",
+      "required": ["account_id", "date", "amount"],
+      "properties": {
+        "account_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "date": {
+          "type": "string",
+          "format": "date"
+        },
+        "amount": {
+          "type": "number",
+          "format": "1234000",
+          "description": "The transaction amount in milliunits format"
+        },
+        "payee_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied."
+        },
+        "category_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied."
+        },
+        "cleared": {
+          "type": "string",
+          "enum": ["Cleared", "Uncleared", "Reconciled"],
+          "description": "The cleared status of the transaction"
+        },
+        "approved": {
+          "type": "boolean",
+          "description": "Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default."
+        },
+        "memo": {
+          "type": "string"
+        }
+      }
+    },
+    "BulkTransactionIds": {
+      "type": "object",
+      "required": ["transaction_ids"],
+      "properties": {
+        "transaction_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BulkTransactionCreateResponse": {
+      "type": "object",
+      "required": ["data"],
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/BulkTransactionIds"
+        }
+      }
+    },
+    "BulkTransactions": {
+      "type": "object",
+      "required": ["transactions"],
+      "properties": {
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SaveTransaction"
+          }
+        }
+      }
     },
     "SubTransaction": {
       "type": "object",

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,7 +20,7 @@ require("portable-fetch");
 
 import { Configuration } from "./configuration";
 
-const USER_AGENT = "api_client/js/0.1.2";
+const USER_AGENT = "api_client/js/0.2.1";
 
 function convertDateToFullDateStringFormat(date: Date | string): string {
   // Convert to RFC 3339 "full-date" format, like "2017-11-27"
@@ -309,6 +309,48 @@ export interface BudgetSummaryWrapper {
      * @memberof BudgetSummaryWrapper
      */
     budgets: Array<BudgetSummary>;
+}
+
+/**
+ * 
+ * @export
+ * @interface BulkTransactionCreateResponse
+ */
+export interface BulkTransactionCreateResponse {
+    /**
+     * 
+     * @type {BulkTransactionIds}
+     * @memberof BulkTransactionCreateResponse
+     */
+    data: BulkTransactionIds;
+}
+
+/**
+ * 
+ * @export
+ * @interface BulkTransactionIds
+ */
+export interface BulkTransactionIds {
+    /**
+     * 
+     * @type {Array&lt;string&gt;}
+     * @memberof BulkTransactionIds
+     */
+    transaction_ids: Array<string>;
+}
+
+/**
+ * 
+ * @export
+ * @interface BulkTransactions
+ */
+export interface BulkTransactions {
+    /**
+     * 
+     * @type {Array&lt;SaveTransaction&gt;}
+     * @memberof BulkTransactions
+     */
+    transactions: Array<SaveTransaction>;
 }
 
 /**
@@ -773,6 +815,78 @@ export interface PayeesWrapper {
      * @memberof PayeesWrapper
      */
     payees: Array<Payee>;
+}
+
+/**
+ * 
+ * @export
+ * @interface SaveTransaction
+ */
+export interface SaveTransaction {
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    account_id: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    date: string;
+    /**
+     * The transaction amount in milliunits format
+     * @type {number}
+     * @memberof SaveTransaction
+     */
+    amount: number;
+    /**
+     * The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    payee_id?: string;
+    /**
+     * The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    category_id?: string;
+    /**
+     * The cleared status of the transaction
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    cleared?: SaveTransaction.ClearedEnum;
+    /**
+     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
+     * @type {boolean}
+     * @memberof SaveTransaction
+     */
+    approved?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    memo?: string;
+}
+
+/**
+ * @export
+ * @namespace SaveTransaction
+ */
+export namespace SaveTransaction {
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum ClearedEnum {
+        Cleared = <any> 'Cleared',
+        Uncleared = <any> 'Uncleared',
+        Reconciled = <any> 'Reconciled'
+    }
 }
 
 /**
@@ -3102,6 +3216,102 @@ export class ScheduledTransactionsApi extends BaseAPI {
 export const TransactionsApiFetchParamCreator = function (configuration?: Configuration) {
     return {
         /**
+         * Creates multiple transactions
+         * @summary Bulk create transactions
+         * @param {string} budget_id - ID of budget
+         * @param {BulkTransactions} transactions - Transactions to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options: any = {}): FetchArgs {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling bulkCreateTransactions.');
+            }
+            // verify required parameter 'transactions' is not null or undefined
+            if (transactions === null || transactions === undefined) {
+                throw new RequiredError('transactions','Required parameter transactions was null or undefined when calling bulkCreateTransactions.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions/bulk`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            localVarRequestOptions.body = JSON.stringify(transactions || {});
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Creates a transaction
+         * @summary Create new transaction
+         * @param {string} budget_id - ID of budget
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        createTransaction(budget_id: string, transaction: SaveTransaction, options: any = {}): FetchArgs {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling createTransaction.');
+            }
+            // verify required parameter 'transaction' is not null or undefined
+            if (transaction === null || transaction === undefined) {
+                throw new RequiredError('transaction','Required parameter transaction was null or undefined when calling createTransaction.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            localVarRequestOptions.body = JSON.stringify(transaction || {});
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Returns budget transactions
          * @summary List transactions
          * @param {string} budget_id - ID of budget
@@ -3299,6 +3509,60 @@ export const TransactionsApiFetchParamCreator = function (configuration?: Config
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Updates a transaction
+         * @summary Updates an existing transaction
+         * @param {string} budget_id - ID of budget
+         * @param {string} transaction_id - ID of transaction
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options: any = {}): FetchArgs {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling updateTransaction.');
+            }
+            // verify required parameter 'transaction_id' is not null or undefined
+            if (transaction_id === null || transaction_id === undefined) {
+                throw new RequiredError('transaction_id','Required parameter transaction_id was null or undefined when calling updateTransaction.');
+            }
+            // verify required parameter 'transaction' is not null or undefined
+            if (transaction === null || transaction === undefined) {
+                throw new RequiredError('transaction','Required parameter transaction was null or undefined when calling updateTransaction.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
+                .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'PUT' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            localVarRequestOptions.body = JSON.stringify(transaction || {});
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -3308,6 +3572,50 @@ export const TransactionsApiFetchParamCreator = function (configuration?: Config
  */
 export const TransactionsApiFp = function(configuration?: Configuration) {
     return {
+        /**
+         * Creates multiple transactions
+         * @summary Bulk create transactions
+         * @param {string} budget_id - ID of budget
+         * @param {BulkTransactions} transactions - Transactions to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any): (fetchFunction?: FetchAPI) => Promise<BulkTransactionCreateResponse> {
+            const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).bulkCreateTransactions(budget_id, transactions, options);
+            return (fetchFunction: FetchAPI = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
+        /**
+         * Creates a transaction
+         * @summary Create new transaction
+         * @param {string} budget_id - ID of budget
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        createTransaction(budget_id: string, transaction: SaveTransaction, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse> {
+            const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).createTransaction(budget_id, transaction, options);
+            return (fetchFunction: FetchAPI = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
         /**
          * Returns budget transactions
          * @summary List transactions
@@ -3399,6 +3707,29 @@ export const TransactionsApiFp = function(configuration?: Configuration) {
                 });
             };
         },
+        /**
+         * Updates a transaction
+         * @summary Updates an existing transaction
+         * @param {string} budget_id - ID of budget
+         * @param {string} transaction_id - ID of transaction
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse> {
+            const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).updateTransaction(budget_id, transaction_id, transaction, options);
+            return (fetchFunction: FetchAPI = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
     }
 };
 
@@ -3408,6 +3739,28 @@ export const TransactionsApiFp = function(configuration?: Configuration) {
  */
 export const TransactionsApiFactory = function (configuration?: Configuration) {
     return {
+        /**
+         * Creates multiple transactions
+         * @summary Bulk create transactions
+         * @param {string} budget_id - ID of budget
+         * @param {BulkTransactions} transactions - Transactions to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any) {
+            return TransactionsApiFp(configuration).bulkCreateTransactions(budget_id, transactions, options)();
+        },
+        /**
+         * Creates a transaction
+         * @summary Create new transaction
+         * @param {string} budget_id - ID of budget
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        createTransaction(budget_id: string, transaction: SaveTransaction, options?: any) {
+            return TransactionsApiFp(configuration).createTransaction(budget_id, transaction, options)();
+        },
         /**
          * Returns budget transactions
          * @summary List transactions
@@ -3455,6 +3808,18 @@ export const TransactionsApiFactory = function (configuration?: Configuration) {
         getTransactionsById(budget_id: string, transaction_id: string, options?: any) {
             return TransactionsApiFp(configuration).getTransactionsById(budget_id, transaction_id, options)();
         },
+        /**
+         * Updates a transaction
+         * @summary Updates an existing transaction
+         * @param {string} budget_id - ID of budget
+         * @param {string} transaction_id - ID of transaction
+         * @param {SaveTransaction} transaction - Transaction to create
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any) {
+            return TransactionsApiFp(configuration).updateTransaction(budget_id, transaction_id, transaction, options)();
+        },
     };
 };
 
@@ -3465,6 +3830,32 @@ export const TransactionsApiFactory = function (configuration?: Configuration) {
  * @extends {BaseAPI}
  */
 export class TransactionsApi extends BaseAPI {
+    /**
+     * Creates multiple transactions
+     * @summary Bulk create transactions
+     * @param {string} budget_id - ID of budget
+     * @param {BulkTransactions} transactions - Transactions to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    public bulkCreateTransactions(budget_id: string, transactions: BulkTransactions, options?: any) {
+        return TransactionsApiFp(this.configuration).bulkCreateTransactions(budget_id, transactions, options)();
+    }
+
+    /**
+     * Creates a transaction
+     * @summary Create new transaction
+     * @param {string} budget_id - ID of budget
+     * @param {SaveTransaction} transaction - Transaction to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    public createTransaction(budget_id: string, transaction: SaveTransaction, options?: any) {
+        return TransactionsApiFp(this.configuration).createTransaction(budget_id, transaction, options)();
+    }
+
     /**
      * Returns budget transactions
      * @summary List transactions
@@ -3518,6 +3909,20 @@ export class TransactionsApi extends BaseAPI {
      */
     public getTransactionsById(budget_id: string, transaction_id: string, options?: any) {
         return TransactionsApiFp(this.configuration).getTransactionsById(budget_id, transaction_id, options)();
+    }
+
+    /**
+     * Updates a transaction
+     * @summary Updates an existing transaction
+     * @param {string} budget_id - ID of budget
+     * @param {string} transaction_id - ID of transaction
+     * @param {SaveTransaction} transaction - Transaction to create
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    public updateTransaction(budget_id: string, transaction_id: string, transaction: SaveTransaction, options?: any) {
+        return TransactionsApiFp(this.configuration).updateTransaction(budget_id, transaction_id, transaction, options)();
     }
 
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,18 @@ export class Utils {
    * Returns the current month (system timezone) in ISO 8601 format (i.e. '2015-12-01')
    */
   public getCurrentMonthInISOFormat() {
+    return `${this.getCurrentDateInISOFormat().substr(0, 7)}-01`;
+  }
+
+  /**
+   * Returns the current date (system timezone) in ISO 8601 format (i.e. '2015-12-15')
+   */
+  public getCurrentDateInISOFormat() {
     let currentDate = new Date();
     let isoLocalDateString = new Date(
       currentDate.getTime() - currentDate.getTimezoneOffset() * 60000
     ).toISOString();
-    let isoFirstDayOfCurrentMonth = `${isoLocalDateString.substr(0, 7)}-01`;
-    return isoFirstDayOfCurrentMonth;
+    return isoLocalDateString;
   }
 
   /**


### PR DESCRIPTION
This PR implements support for the newly added ability to create/update/bulk create transactions through the Public API.

The swagger generator was run to update the client and a new example for bulk creation was added.