### PR TITLE
Remove references to portable-fetch.d.ts

### DIFF
--- a/build/swagger-config-typescript.json
+++ b/build/swagger-config-typescript.json
@@ -1,5 +1,5 @@
 {
   "npmName": "ynab",
-  "npmVersion": "0.9.0",
+  "npmVersion": "0.11.0",
   "supportsES6": true
 }

--- a/build/swagger-templates/api.mustache
+++ b/build/swagger-templates/api.mustache
@@ -1,4 +1,3 @@
-/// <reference path="./portable-fetch.d.ts" />
 // tslint:disable
 {{>licenseInfo}}
 

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -123,6 +123,7 @@ export declare namespace Account {
         Cash,
         LineOfCredit,
         MerchantAccount,
+        PayPal,
         InvestmentAccount,
         Mortgage,
         OtherAsset,
@@ -991,7 +992,7 @@ export interface ScheduledTransactionSummary {
      */
     memo: string;
     /**
-     * The transaction flag
+     * The scheduled transaction flag
      * @type {string}
      * @memberof ScheduledTransactionSummary
      */
@@ -1512,7 +1513,7 @@ export interface ScheduledTransactionDetail {
      */
     memo: string;
     /**
-     * The transaction flag
+     * The scheduled transaction flag
      * @type {string}
      * @memberof ScheduledTransactionDetail
      */

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../src/portable-fetch.d.ts" />
 import { Configuration } from "./configuration";
 /**
  *

--- a/dist/api.js
+++ b/dist/api.js
@@ -16,7 +16,7 @@ const url = require("url");
 // Requiring portable-fetch like this ensures that we have a global fetch function
 // That makes it easier to override with modules like fetch-mock
 require("portable-fetch");
-const USER_AGENT = "api_client/js/0.9.0";
+const USER_AGENT = "api_client/js/0.11.0";
 function convertDateToFullDateStringFormat(date) {
     // Convert to RFC 3339 "full-date" format, like "2017-11-27"
     if (date instanceof Date) {
@@ -81,6 +81,7 @@ var Account;
         TypeEnum[TypeEnum["Cash"] = 'cash'] = "Cash";
         TypeEnum[TypeEnum["LineOfCredit"] = 'lineOfCredit'] = "LineOfCredit";
         TypeEnum[TypeEnum["MerchantAccount"] = 'merchantAccount'] = "MerchantAccount";
+        TypeEnum[TypeEnum["PayPal"] = 'payPal'] = "PayPal";
         TypeEnum[TypeEnum["InvestmentAccount"] = 'investmentAccount'] = "InvestmentAccount";
         TypeEnum[TypeEnum["Mortgage"] = 'mortgage'] = "Mortgage";
         TypeEnum[TypeEnum["OtherAsset"] = 'otherAsset'] = "OtherAsset";

--- a/dist/api.js
+++ b/dist/api.js
@@ -1,5 +1,4 @@
 "use strict";
-/// <reference path="./portable-fetch.d.ts" />
 // tslint:disable
 /**
  * YNAB API Endpoints

--- a/spec-v1-swagger.json
+++ b/spec-v1-swagger.json
@@ -1301,6 +1301,7 @@
             "cash",
             "lineOfCredit",
             "merchantAccount",
+            "payPal",
             "investmentAccount",
             "mortgage",
             "otherAsset",
@@ -1965,7 +1966,7 @@
         "flag_color": {
           "type": "string",
           "enum": ["red", "orange", "yellow", "green", "blue", "purple", null],
-          "description": "The transaction flag"
+          "description": "The scheduled transaction flag"
         },
         "account_id": {
           "type": "string",

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,7 +19,7 @@ require("portable-fetch");
 
 import { Configuration } from "./configuration";
 
-const USER_AGENT = "api_client/js/0.9.0";
+const USER_AGENT = "api_client/js/0.11.0";
 
 function convertDateToFullDateStringFormat(date: Date | string): string {
   // Convert to RFC 3339 "full-date" format, like "2017-11-27"
@@ -166,6 +166,7 @@ export namespace Account {
         Cash = <any> 'cash',
         LineOfCredit = <any> 'lineOfCredit',
         MerchantAccount = <any> 'merchantAccount',
+        PayPal = <any> 'payPal',
         InvestmentAccount = <any> 'investmentAccount',
         Mortgage = <any> 'mortgage',
         OtherAsset = <any> 'otherAsset',
@@ -1078,7 +1079,7 @@ export interface ScheduledTransactionSummary {
      */
     memo: string;
     /**
-     * The transaction flag
+     * The scheduled transaction flag
      * @type {string}
      * @memberof ScheduledTransactionSummary
      */
@@ -1614,7 +1615,7 @@ export interface ScheduledTransactionDetail {
      */
     memo: string;
     /**
-     * The transaction flag
+     * The scheduled transaction flag
      * @type {string}
      * @memberof ScheduledTransactionDetail
      */

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,3 @@
-/// <reference path="./portable-fetch.d.ts" />
 // tslint:disable
 /**
  * YNAB API Endpoints

--- a/src/portable-fetch.d.ts
+++ b/src/portable-fetch.d.ts
@@ -1,1 +1,0 @@
-declare module 'portable-fetch';


### PR DESCRIPTION
- Remove references to portable-fetch.d.ts (no longer needed)
- Generate from latest server spec portable-fetch.d.ts (no longer needed)