### PR TITLE
Add additional API export that is capitalized for linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://badge.fury.io/js/ynab.svg)](https://badge.fury.io/js/ynab)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
-**NOTE: The YNAB API is currently only available to Early Access users.  If you are interested in requesting access before the API is generally available, please fill out [this form](https://docs.google.com/forms/d/17plY-CE39Xl3pe2GqyVH1Unre8TjYKs-tkI6jVC4ko4/edit).**
+**NOTE: The YNAB API is currently only available to Early Access users. If you are interested in requesting access before the API is generally available, please fill out [this form](https://docs.google.com/forms/d/17plY-CE39Xl3pe2GqyVH1Unre8TjYKs-tkI6jVC4ko4/edit).**
 
 Please read the [YNAB API documentation](https://api.youneedabudget.com) for an overview of using the API and a complete list of available resources.
 
@@ -36,7 +36,7 @@ import * as ynab from "ynab";
 
 The API supports [Cross Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for asynchronous browser requests from any origin.
 
-The `dist/browser/ynab.js` file (located in node_modules/ynab after installation) is specifically built to run in a browser / window context and exports `ynab` variable to global namespace.  No other dependencies are needed.
+The `dist/browser/ynab.js` file (located in node_modules/ynab after installation) is specifically built to run in a browser / window context and exports `ynab` variable to global namespace. No other dependencies are needed.
 
 ```
 <script src="ynab.js" async></script>
@@ -45,7 +45,6 @@ The `dist/browser/ynab.js` file (located in node_modules/ynab after installation
   var ynab = window.ynab;
 </script>
 ```
-
 
 ## Usage
 
@@ -56,12 +55,12 @@ application.
 
 ```typescript
 const accessToken = "b43439eaafe2_this_is_fake_b43439eaafe2";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 (async function() {
   const budgetsResponse = await ynabAPI.budgets.getBudgets();
   const budgets = budgetsResponse.data.budgets;
-  for(let budget of budgets) {
+  for (let budget of budgets) {
     console.log(`Budget Name: ${budget.name}`);
   }
 })();
@@ -75,9 +74,10 @@ the response will be "thrown" as an error to be caught.
 ```typescript
 const ynab = require("ynab");
 const accessToken = "invalid_token";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
-const budgetsResponse = ynabAPI.budgets.getBudgets()
+const budgetsResponse = ynabAPI.budgets
+  .getBudgets()
   .then(budgetsResponse => {
     // Won't get here because an error will be thrown
   })
@@ -100,33 +100,33 @@ folder for example usage scenarios.
 
 ## Methods
 
-The following methods are available in this library.  For more details on parameters and usage, the [TypeScript declaration file](https://github.com/ynab/ynab-sdk-js/blob/master/dist/api.d.ts) can be referenced.
+The following methods are available in this library. For more details on parameters and usage, the [TypeScript declaration file](https://github.com/ynab/ynab-sdk-js/blob/master/dist/api.d.ts) can be referenced.
 
-|                       | Method                                                | Description                                                                                            |
-|------------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| **User**                | `budgets.getUser()`                                  | Returns authenticated user information
-| **Budgets**                | `budgets.getBudgets()`                                  | Returns budgets list with summary information                                                          |
-|                        | `budgets.getBudgetById(id)`                             | Returns a single budget with all related entities |
-| **Accounts**               | `accounts.getAccounts(budgetId)`                                | Returns all accounts                                                                                   |
-|                        | `accounts.getAccountById(budgetId, id)`                           | Returns a single account                                                                               |
-| **Categories**             | `categories.getCategories(budgetId)`                            | Returns all categories grouped by category group.                                                      |
-|                        | `categories.getCategoryById(budgetId, id)`                        | Returns a single category                                                                              |
-| **Payees**                 | `payees.getPayees(budgetId)`                                    | Returns all payees                                                                                     |
-|                        | `payees.getPayeeById(budgetId, id)`                               | Returns single payee                                                                                   |
-| **Payee Locations**        | `payeeLocations.getPayeeLocations(budgetId)`                    | Returns all payee locations                                                                            |
-|                        | `payeeLocations.getPayeeLocationById(budgetId, id)`               | Returns a single payee location                                                                        |
-|                        | `payeeLocations.getPayeeLocationsByPayee(budgetId, id)`           | Returns all payee locations for the specified payee                                                    |
-| **Months**                 | `months.getBudgetMonths(budgetId)`                              | Returns all budget months                                                                              |
-|                        | `months.getBudgetMonth(budgetId, month)`                             | Returns a single budget month                                                                          |
-| **Transactions**           | `transactions.getTransactions(budgetId)`                        | Returns budget transactions                                                                            |
-|                        | `transactions.getTransactionsByAccount(budgetId, id)`               | Returns all transactions for a specified account                                                       |
-|                        | `transactions.getTransactionsByCategory(budgetId, id)`              | Returns all transactions for a specified category                                                      |
-|                        | `transactions.getTransactionsById(budgetId, id)`                  | Returns a single transaction                                                                           |
-|                        | `transactions.updateTransaction(budgetId, id, transaction)`                      | Updates a transaction                                                                                   |
-|                        | `transactions.createTransaction(budgetId, transaction)`                      | Creates a new transaction                                                                              |
-|                        | `transactions.bulkCreateTransactions(budgetId, transactions)`                 | Creates multiple transactions                                                                          |
-| **Scheduled Transactions** | `scheduledTransactions.getScheduledTransactions(budgetId)`      | Returns all scheduled transactions                                                                     |
-|                        | `scheduledTransactions.getScheduledTransactionById(budgetId, id)` | Returns a single scheduled transaction                                                                 |
+|                            | Method                                                            | Description                                         |
+| -------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| **User**                   | `budgets.getUser()`                                               | Returns authenticated user information              |
+| **Budgets**                | `budgets.getBudgets()`                                            | Returns budgets list with summary information       |
+|                            | `budgets.getBudgetById(id)`                                       | Returns a single budget with all related entities   |
+| **Accounts**               | `accounts.getAccounts(budgetId)`                                  | Returns all accounts                                |
+|                            | `accounts.getAccountById(budgetId, id)`                           | Returns a single account                            |
+| **Categories**             | `categories.getCategories(budgetId)`                              | Returns all categories grouped by category group.   |
+|                            | `categories.getCategoryById(budgetId, id)`                        | Returns a single category                           |
+| **Payees**                 | `payees.getPayees(budgetId)`                                      | Returns all payees                                  |
+|                            | `payees.getPayeeById(budgetId, id)`                               | Returns single payee                                |
+| **Payee Locations**        | `payeeLocations.getPayeeLocations(budgetId)`                      | Returns all payee locations                         |
+|                            | `payeeLocations.getPayeeLocationById(budgetId, id)`               | Returns a single payee location                     |
+|                            | `payeeLocations.getPayeeLocationsByPayee(budgetId, id)`           | Returns all payee locations for the specified payee |
+| **Months**                 | `months.getBudgetMonths(budgetId)`                                | Returns all budget months                           |
+|                            | `months.getBudgetMonth(budgetId, month)`                          | Returns a single budget month                       |
+| **Transactions**           | `transactions.getTransactions(budgetId)`                          | Returns budget transactions                         |
+|                            | `transactions.getTransactionsByAccount(budgetId, id)`             | Returns all transactions for a specified account    |
+|                            | `transactions.getTransactionsByCategory(budgetId, id)`            | Returns all transactions for a specified category   |
+|                            | `transactions.getTransactionsById(budgetId, id)`                  | Returns a single transaction                        |
+|                            | `transactions.updateTransaction(budgetId, id, transaction)`       | Updates a transaction                               |
+|                            | `transactions.createTransaction(budgetId, transaction)`           | Creates a new transaction                           |
+|                            | `transactions.bulkCreateTransactions(budgetId, transactions)`     | Creates multiple transactions                       |
+| **Scheduled Transactions** | `scheduledTransactions.getScheduledTransactions(budgetId)`        | Returns all scheduled transactions                  |
+|                            | `scheduledTransactions.getScheduledTransactionById(budgetId, id)` | Returns a single scheduled transaction              |
 
 ### Utilities
 

--- a/examples/budget-list/index.js
+++ b/examples/budget-list/index.js
@@ -1,23 +1,26 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ynab = require("../../dist/index.js");
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
-(async function () {
-    console.log(`Fetching budgets...`);
-    try {
-        const budgetsResponse = await ynabAPI.budgets.getBudgets();
-        const budgets = budgetsResponse.data.budgets;
-        console.log(`This user has ${budgets.length} budgets.`);
-        console.log(`\
+const ynabAPI = new ynab.API(accessToken);
+(async function() {
+  console.log(`Fetching budgets...`);
+  try {
+    const budgetsResponse = await ynabAPI.budgets.getBudgets();
+    const budgets = budgetsResponse.data.budgets;
+    console.log(`This user has ${budgets.length} budgets.`);
+    console.log(`\
 ===========
 BUDGET LIST
 ===========
 `);
-        for (let budget of budgets) {
-            console.log(`[id: ${budget.id}, name: ${budget.name}, last_modified_on: ${budget.last_modified_on}]`);
-        }
+    for (let budget of budgets) {
+      console.log(
+        `[id: ${budget.id}, name: ${budget.name}, last_modified_on: ${
+          budget.last_modified_on
+        }]`
+      );
     }
-    catch (e) {
-        console.log(`ERROR: ${JSON.stringify(e)}`);
-    }
+  } catch (e) {
+    console.log(`ERROR: ${JSON.stringify(e)}`);
+  }
 })();

--- a/examples/budget-list/index.ts
+++ b/examples/budget-list/index.ts
@@ -1,7 +1,7 @@
 import * as ynab from "../../dist/index.js";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 (async function() {
   console.log(`Fetching budgets...`);

--- a/examples/budget-month/index.js
+++ b/examples/budget-month/index.js
@@ -1,7 +1,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ynab = require("../../dist/index.js");
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 ynabAPI.months
     .getBudgetMonth("f968197b-2863-473a-8974-c2406dbe7f0d", ynab.utils.getCurrentMonthInISOFormat())
     .then(response => {

--- a/examples/budget-month/index.ts
+++ b/examples/budget-month/index.ts
@@ -1,7 +1,7 @@
 import * as ynab from "../../dist/index.js";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 ynabAPI.months
   .getBudgetMonth(

--- a/examples/bulk-transaction-create/index.js
+++ b/examples/bulk-transaction-create/index.js
@@ -1,7 +1,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ynab = require("../../dist/index.js");
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 const bulkTransactions = {
     transactions: [
         {

--- a/examples/bulk-transaction-create/index.ts
+++ b/examples/bulk-transaction-create/index.ts
@@ -1,7 +1,7 @@
 import * as ynab from "../../dist/index.js";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 const bulkTransactions: ynab.BulkTransactions = {
   transactions: [

--- a/examples/category-balance/index.js
+++ b/examples/category-balance/index.js
@@ -1,7 +1,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ynab = require("../../dist/index.js");
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 ynabAPI.categories
     .getCategoryById("f968197b-2863-473a-8974-c2406dbe7f0d", "697b1c31-3740-4816-82fc-3299cf26889d")
     .then(response => {

--- a/examples/category-balance/index.ts
+++ b/examples/category-balance/index.ts
@@ -1,7 +1,7 @@
 import * as ynab from "../../dist/index.js";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 ynabAPI.categories
   .getCategoryById(

--- a/examples/delta-request/index.js
+++ b/examples/delta-request/index.js
@@ -1,7 +1,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ynab = require("../../dist/index.js");
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 (async function () {
     try {
         // You can get your API key from the My Account section of YNAB
@@ -10,7 +10,7 @@ const ynabAPI = new ynab.api(accessToken);
             console.warn("You will need to define the YNAB_API_ACCESS_TOKEN environment variable.");
             process.exit(1);
         }
-        const ynabAPI = new ynab.api(API_KEY);
+        const ynabAPI = new ynab.API(API_KEY);
         console.log(`Fetching budgets...`);
         const getBudgetsResponse = await ynabAPI.budgets.getBudgets();
         const allBudgets = getBudgetsResponse.data.budgets;

--- a/examples/delta-request/index.ts
+++ b/examples/delta-request/index.ts
@@ -1,7 +1,7 @@
 import * as ynab from "../../dist/index.js";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 (async function() {
   try {
@@ -13,7 +13,7 @@ const ynabAPI = new ynab.api(accessToken);
       );
       process.exit(1);
     }
-    const ynabAPI = new ynab.api(API_KEY);
+    const ynabAPI = new ynab.API(API_KEY);
 
     console.log(`Fetching budgets...`);
     const getBudgetsResponse = await ynabAPI.budgets.getBudgets();

--- a/examples/update-transaction/index.js
+++ b/examples/update-transaction/index.js
@@ -1,7 +1,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ynab = require("../../dist/index.js");
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 const budgetId = "f968197b-2863-473a-8974-c2406dbe7f0d";
 const transactionId = "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da";
 (async function () {

--- a/examples/update-transaction/index.ts
+++ b/examples/update-transaction/index.ts
@@ -1,7 +1,7 @@
 import * as ynab from "../../dist/index.js";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
-const ynabAPI = new ynab.api(accessToken);
+const ynabAPI = new ynab.API(accessToken);
 
 const budgetId = "f968197b-2863-473a-8974-c2406dbe7f0d";
 const transactionId = "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import { Configuration } from "./configuration";
 import * as CodeGen from "./api";
 import utils from "./utils";
 
-export * from "./api";
+export { api as API };
 export { utils };
+export * from "./api";
 
 /**
  * The YNAB API client

--- a/test/requestTests.ts
+++ b/test/requestTests.ts
@@ -38,7 +38,7 @@ describe("API requests", () => {
 
   describe("/budgets", () => {
     it("Should throw the response it is sent back with a status of 400", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const errorObject = {
         error: {
@@ -64,7 +64,7 @@ describe("API requests", () => {
     });
 
     it("Should getBudgets and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const getBudgetsResponse = await callApiAndVerifyResponse(
         () => ynabAPI.budgets.getBudgets(0),
@@ -74,7 +74,7 @@ describe("API requests", () => {
     });
 
     it("Should getBudgetById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const lastKnowledgeOfServer = 5;
       const getBudgetsResponse = await callApiAndVerifyResponse(
@@ -89,7 +89,7 @@ describe("API requests", () => {
 
   describe("/budgets/accounts", () => {
     it("Should getAccounts and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.accounts.getAccounts(budgetId),
@@ -99,7 +99,7 @@ describe("API requests", () => {
     });
 
     it("Should getAccountById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const accountId = "DummyAccountId";
       const returnedResponse = await callApiAndVerifyResponse(
@@ -112,7 +112,7 @@ describe("API requests", () => {
     });
 
     it("Should escape Ids in the URL", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const budgetId = "/://{}?";
       const accountId = "/://{}?";
@@ -131,7 +131,7 @@ describe("API requests", () => {
   describe("/budgets/categories", () => {
     it("Should getCategories and validate the request is sent correctly", async () => {
       const mockResponse = factories.categoriesResponseFactory.build();
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const accountId = "DummyAccountId";
       const returnedResponse = await callApiAndVerifyResponse(
@@ -142,7 +142,7 @@ describe("API requests", () => {
     });
 
     it("Should getCategoryById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const categoryId = "DummyCategoryId";
       const returnedResponse = await callApiAndVerifyResponse(
@@ -157,7 +157,7 @@ describe("API requests", () => {
 
   describe("/budgets/months", () => {
     it("Should getBudgetMonths and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonths(budgetId),
@@ -167,7 +167,7 @@ describe("API requests", () => {
     });
 
     it("Should getBudgetMonth and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const budgetMonth = getUTCDate(2017, 1, 1);
       const returnedResponse = await callApiAndVerifyResponse(
@@ -178,7 +178,7 @@ describe("API requests", () => {
     });
 
     it("Should getBudgetMonth with a string param and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonth(budgetId, "2017-01"),
@@ -188,7 +188,7 @@ describe("API requests", () => {
     });
 
     it("Should getBudgetMonth with a string param of 'current' and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonth(budgetId, "current"),
@@ -200,7 +200,7 @@ describe("API requests", () => {
 
   describe("/budgets/payees", () => {
     it("Should getPayees and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.payees.getPayees(budgetId),
@@ -210,7 +210,7 @@ describe("API requests", () => {
     });
 
     it("Should getPayeeById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const payeeId = "payeeId";
       const returnedResponse = await callApiAndVerifyResponse(
@@ -223,7 +223,7 @@ describe("API requests", () => {
 
   describe("/budgets/payee_locations", () => {
     it("Should getPayeeLocations and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.payeeLocations.getPayeeLocations(budgetId),
@@ -233,7 +233,7 @@ describe("API requests", () => {
     });
 
     it("Should getPayeeLocationById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const payeeLocationId = "payeeLocationId";
       const returnedResponse = await callApiAndVerifyResponse(
@@ -252,7 +252,7 @@ describe("API requests", () => {
 
   describe("/budgets/transactions", () => {
     it("Should getTransactions and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.transactions.getTransactions(budgetId),
@@ -262,7 +262,7 @@ describe("API requests", () => {
     });
 
     it("Should getTransactionById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const transactionId = "TransactionId";
       const returnedResponse = await callApiAndVerifyResponse(
@@ -275,7 +275,7 @@ describe("API requests", () => {
     });
 
     it("Should getTransactionsByAccount and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const accountId = "accountId";
       const sinceDate = getUTCDate(2017, 1, 1);
@@ -294,7 +294,7 @@ describe("API requests", () => {
     });
 
     it("Should getTransactionsByAccount with a string `sinceDate` and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const accountId = "accountId";
       const sinceDate = "2017-02";
@@ -313,7 +313,7 @@ describe("API requests", () => {
     });
 
     it("Should getTransactionsByCategory and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const categoryId = "categoryId";
       const sinceDate = getUTCDate(2017, 1, 1);
@@ -332,7 +332,7 @@ describe("API requests", () => {
     });
 
     it("Should getTransactionsByCategory with a string `sinceDate` and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const categoryId = "categoryId";
       // Make sure we can pass a string as well
@@ -352,7 +352,7 @@ describe("API requests", () => {
     });
 
     it("Should createTransaction", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () =>
@@ -372,7 +372,7 @@ describe("API requests", () => {
     });
 
     it("Should updateTransaction", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
       const transactionId = "B5F12BF2-AFCD-4447-BE3E-1855D3B23ECC";
       const returnedResponse = await callApiAndVerifyResponse(
         () =>
@@ -393,7 +393,7 @@ describe("API requests", () => {
     });
 
     it("Should bulkCreateTransactions", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
       const transactionId = "B5F12BF2-AFCD-4447-BE3E-1855D3B23ECC";
       const returnedResponse = await callApiAndVerifyResponse(
         () =>
@@ -415,7 +415,7 @@ describe("API requests", () => {
 
   describe("/budgets/scheduled_transactions", () => {
     it("Should getScheduledTransactions and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const returnedResponse = await callApiAndVerifyResponse(
         () => ynabAPI.scheduledTransactions.getScheduledTransactions(budgetId),
@@ -427,7 +427,7 @@ describe("API requests", () => {
     });
 
     it("Should getScheduledTransactionById and validate the request is sent correctly", async () => {
-      const ynabAPI = new ynab.api(API_KEY, BASE_URL);
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const scheduledTransactionId = "scheduledTransactionId";
       const returnedResponse = await callApiAndVerifyResponse(


### PR DESCRIPTION
Fixes #41 

Add additional `API` export that is capitalized for linters.  Lowercased version is still available.  Also, do some misc formatting with prettier.