### PR TITLE
[Spec Change Request] Remove nullable goal fields from 'required'

### DIFF
--- a/spec-v1-swagger.json
+++ b/spec-v1-swagger.json
@@ -1853,11 +1853,7 @@
         "budgeted",
         "activity",
         "balance",
-        "goal_type",
-        "goal_creation_month",
         "goal_target",
-        "goal_target_month",
-        "goal_percentage_complete",
         "deleted"
       ],
       "properties": {


### PR DESCRIPTION
Looks like a few of the Category 'goal' fields weren't removed from the required section in commit: [02e520b8f3f717576bf05bbca8ceb68ca753390e](https://github.com/ynab/ynab-sdk-js/commit/02e520b8f3f717576bf05bbca8ceb68ca753390e#diff-2852aac85aad155f59f71b70ba0722fb) but the API returns null for those fields on a new budget as of 8/28/19 which makes sense to me. 
e.g.
```json
...
 {
                    "id": "028a9a5d-38bd-4863-a9b6-917a4119246f",
                    "category_group_id": "c37f3509-ef78-443a-8cd0-22211a1ab167",
                    "name": "Deferred Income SubCategory",
                    "hidden": false,
                    "original_category_group_id": null,
                    "note": null,
                    "budgeted": 0,
                    "activity": 0,
                    "balance": 0,
                    "goal_type": null,
                    "goal_creation_month": null,
                    "goal_target": 0,
                    "goal_target_month": null,
                    "goal_percentage_complete": null,
                    "deleted": false
                },
...
```