### PR TITLE
New method: `transactions.getTransactionsByType`

### DIFF
--- a/src/transactionsApi.ts
+++ b/src/transactionsApi.ts
@@ -2,6 +2,31 @@ import * as CodeGen from "./api";
 
 export class TransactionsApi extends CodeGen.TransactionsApi {
   /**
+   * Returns budget transactions by type
+   * @summary List transactions
+   * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+   * @param {&#39;uncategorized&#39; | &#39;unapproved&#39;} [type] - If specified, only transactions of the specified type will be included. \"uncategorized\" and \"unapproved\" are currently supported.
+   * @param {number} [last_knowledge_of_server] - The starting server knowledge.  If provided, only entities that have changed since `last_knowledge_of_server` will be included.
+   * @param {*} [options] - Override http request options.
+   * @throws {RequiredError}
+   * @memberof TransactionsApi
+   */
+  public getTransactionsByType(
+    budget_id: string,
+    type: "uncategorized" | "unapproved",
+    last_knowledge_of_server?: number,
+    options?: any
+  ) {
+    return CodeGen.TransactionsApiFp(this.configuration).getTransactions(
+      budget_id,
+      undefined,
+      type,
+      last_knowledge_of_server,
+      options
+    )();
+  }
+
+  /**
    * Creates multiple transactions. Provide a body containing a 'transactions' array, multiple transactions will be created.
    * @summary Create a single transaction or multiple transactions
    * @param {string} budget_id - The id of the budget (\"last-used\" can also be used to specify the last used budget)

--- a/test/requestTests.ts
+++ b/test/requestTests.ts
@@ -291,6 +291,17 @@ describe("API requests", () => {
       verifyRequestDetails(`${BASE_URL}/budgets/${budgetId}/transactions`);
     });
 
+    it("Should getTransactionsByType and validate the request is sent correctly", async () => {
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
+
+      const returnedResponse = await callApiAndVerifyResponse(
+        () =>
+          ynabAPI.transactions.getTransactionsByType(budgetId, "uncategorized"),
+        factories.transactionsResponseFactory.build()
+      );
+      verifyRequestDetails(`${BASE_URL}/budgets/${budgetId}/transactions?type=uncategorized`);
+    });
+
     it("Should getTransactionById and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 


### PR DESCRIPTION
New method being added: `transactions.getTransactionsByType`.

This will allow a convenient way to retrieve uncategorized or unapproved transactions and avoid having to pass `defined` in as `since_date` parameter on `transactions.getTransactions`.

### Example usage

```
ynabAPI.transactions.getTransactionsByType("last-used", "uncategorized")
ynabAPI.transactions.getTransactionsByType("last-used", "unapproved")
```

Fixes #112