### PR TITLE
Pull in new account types from latest spec

### DIFF
--- a/.swagger-codegen/config.json
+++ b/.swagger-codegen/config.json
@@ -1,5 +1,5 @@
 {
   "npmName": "ynab",
-  "npmVersion": "1.28.0",
+  "npmVersion": "1.29.0",
   "supportsES6": true
 }

--- a/.swagger-codegen/spec-v1-swagger.json
+++ b/.swagger-codegen/spec-v1-swagger.json
@@ -1801,21 +1801,7 @@
           "type": "string"
         },
         "type": {
-          "type": "string",
-          "description": "The type of account. Note: payPal, merchantAccount, investmentAccount, and mortgage types have been deprecated and will be removed in the future.",
-          "enum": [
-            "checking",
-            "savings",
-            "cash",
-            "creditCard",
-            "lineOfCredit",
-            "otherAsset",
-            "otherLiability",
-            "payPal",
-            "merchantAccount",
-            "investmentAccount",
-            "mortgage"
-          ]
+          "$ref": "#/definitions/AccountType"
         },
         "on_budget": {
           "type": "boolean",
@@ -1880,9 +1866,7 @@
           "description": "The name of the account"
         },
         "type": {
-          "type": "string",
-          "enum": ["checking", "savings", "creditCard", "cash", "lineOfCredit", "otherAsset", "otherLiability"],
-          "description": "The account type"
+          "$ref": "#/definitions/AccountType"
         },
         "balance": {
           "type": "integer",
@@ -1890,6 +1874,25 @@
           "description": "The current balance of the account in milliunits format"
         }
       }
+    },
+    "AccountType": {
+      "type": "string",
+      "description": "The type of account",
+      "enum": [
+        "checking",
+        "savings",
+        "cash",
+        "creditCard",
+        "lineOfCredit",
+        "otherAsset",
+        "otherLiability",
+        "mortgage",
+        "autoLoan",
+        "studentLoan",
+        "personalLoan",
+        "medicalDebt",
+        "otherDebt"
+      ]
     },
     "CategoriesResponse": {
       "type": "object",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^14.0.27",
         "chai": "^4.2.0",
         "fetch-mock": "^9.10.6",
-        "jsh": "^0.32.0",
+        "jsh": "0.34.0",
         "mocha": "^8.1.1",
         "npm-github-release": "^0.13.0",
         "swagger-model-validator": "^3.0.19",
@@ -2015,9 +2015,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2802,9 +2802,9 @@
       "dev": true
     },
     "node_modules/jsh": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/jsh/-/jsh-0.32.0.tgz",
-      "integrity": "sha512-he4K/OAFw0UN62syneIXO5uOcWd22SVwmkYH25XBfraVPaReYuDsbz+lj273L+96GgPCijcGja6VIY2Bu5ISEg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/jsh/-/jsh-0.34.0.tgz",
+      "integrity": "sha512-9ctsE3Z8QN6FGwwQ6EF2voDJQtN0UwxSSO02CaJrxBemx+LLnvhFC4l5mq/QDxDseon4j9c7/v6Ve0Iz9WkzQQ==",
       "dev": true,
       "bin": {
         "jsh": "bin/jsh.mjs"
@@ -6892,9 +6892,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -7519,9 +7519,9 @@
       "dev": true
     },
     "jsh": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/jsh/-/jsh-0.32.0.tgz",
-      "integrity": "sha512-he4K/OAFw0UN62syneIXO5uOcWd22SVwmkYH25XBfraVPaReYuDsbz+lj273L+96GgPCijcGja6VIY2Bu5ISEg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/jsh/-/jsh-0.34.0.tgz",
+      "integrity": "sha512-9ctsE3Z8QN6FGwwQ6EF2voDJQtN0UwxSSO02CaJrxBemx+LLnvhFC4l5mq/QDxDseon4j9c7/v6Ve0Iz9WkzQQ==",
       "dev": true
     },
     "json-parse-even-better-errors": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14.0.27",
     "chai": "^4.2.0",
     "fetch-mock": "^9.10.6",
-    "jsh": "^0.32.0",
+    "jsh": "0.34.0",
     "mocha": "^8.1.1",
     "npm-github-release": "^0.13.0",
     "swagger-model-validator": "^3.0.19",

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,7 @@ if (!globalThis.fetch) {
 import * as url from "url";
 import { Configuration } from "./configuration";
 
-const USER_AGENT = "api_client/js/1.28.0";
+const USER_AGENT = "api_client/js/1.29.0";
 
 function convertDateToFullDateStringFormat(date: Date | string): string {
   // Convert to RFC 3339 "full-date" format, like "2017-11-27"
@@ -112,11 +112,11 @@ export interface Account {
      */
     name: string;
     /**
-     * The type of account. Note: payPal, merchantAccount, investmentAccount, and mortgage types have been deprecated and will be removed in the future.
-     * @type {string}
+     * 
+     * @type {AccountType}
      * @memberof Account
      */
-    type: Account.TypeEnum;
+    type: AccountType;
     /**
      * Whether this account is on budget or not
      * @type {boolean}
@@ -180,30 +180,6 @@ export interface Account {
 }
 
 /**
- * @export
- * @namespace Account
- */
-export namespace Account {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum TypeEnum {
-        Checking = <any> 'checking',
-        Savings = <any> 'savings',
-        Cash = <any> 'cash',
-        CreditCard = <any> 'creditCard',
-        LineOfCredit = <any> 'lineOfCredit',
-        OtherAsset = <any> 'otherAsset',
-        OtherLiability = <any> 'otherLiability',
-        PayPal = <any> 'payPal',
-        MerchantAccount = <any> 'merchantAccount',
-        InvestmentAccount = <any> 'investmentAccount',
-        Mortgage = <any> 'mortgage'
-    }
-}
-
-/**
  * 
  * @export
  * @interface AccountResponse
@@ -229,6 +205,27 @@ export interface AccountResponseData {
      * @memberof AccountResponseData
      */
     account: Account;
+}
+
+/**
+ * The type of account
+ * @export
+ * @enum {string}
+ */
+export enum AccountType {
+    Checking = <any> 'checking',
+    Savings = <any> 'savings',
+    Cash = <any> 'cash',
+    CreditCard = <any> 'creditCard',
+    LineOfCredit = <any> 'lineOfCredit',
+    OtherAsset = <any> 'otherAsset',
+    OtherLiability = <any> 'otherLiability',
+    Mortgage = <any> 'mortgage',
+    AutoLoan = <any> 'autoLoan',
+    StudentLoan = <any> 'studentLoan',
+    PersonalLoan = <any> 'personalLoan',
+    MedicalDebt = <any> 'medicalDebt',
+    OtherDebt = <any> 'otherDebt'
 }
 
 /**
@@ -1190,37 +1187,17 @@ export interface SaveAccount {
      */
     name: string;
     /**
-     * The account type
-     * @type {string}
+     * 
+     * @type {AccountType}
      * @memberof SaveAccount
      */
-    type: SaveAccount.TypeEnum;
+    type: AccountType;
     /**
      * The current balance of the account in milliunits format
      * @type {number}
      * @memberof SaveAccount
      */
     balance: number;
-}
-
-/**
- * @export
- * @namespace SaveAccount
- */
-export namespace SaveAccount {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum TypeEnum {
-        Checking = <any> 'checking',
-        Savings = <any> 'savings',
-        CreditCard = <any> 'creditCard',
-        Cash = <any> 'cash',
-        LineOfCredit = <any> 'lineOfCredit',
-        OtherAsset = <any> 'otherAsset',
-        OtherLiability = <any> 'otherLiability'
-    }
 }
 
 /**

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -46,7 +46,7 @@ export const budgetSummaryResponseFactory = Factory.makeFactory<
 export const accountFactory = Factory.makeFactory<api.Account>({
   id: Factory.each((i) => `AccountID${i}`),
   name: Factory.each((i) => `Account ${i}`),
-  type: api.Account.TypeEnum.Checking,
+  type: api.AccountType.Checking,
   on_budget: true,
   closed: false,
   note: Factory.each((i) => `Note #${i}`),
@@ -78,7 +78,7 @@ export const accountResponseFactory = Factory.makeFactory<
 
 export const saveAccountFactory = Factory.makeFactory<api.SaveAccount>({
   name: `AccountID${1}`,
-  type: api.SaveAccount.TypeEnum.Checking,
+  type: api.AccountType.Checking,
   balance: 140235,
 });
 


### PR DESCRIPTION
This regenerates from the latest spec to pull in the latest list of account types, which includes new loan account types.

As part of this change, the enum of account types has been moved from `api.SaveAccount.TypeEnum` to `api.AccountType`.

Before:
```
 type: api.SaveAccount.TypeEnum.Checking
```
After:
```
 type: api.AccountType.Checking
```