### PR TITLE
New support for deleting transactions

### DIFF
--- a/.swagger-codegen/config.json
+++ b/.swagger-codegen/config.json
@@ -1,5 +1,5 @@
 {
   "npmName": "ynab",
-  "npmVersion": "1.32.0",
+  "npmVersion": "1.42.0",
   "supportsES6": true
 }

--- a/.swagger-codegen/generate.js
+++ b/.swagger-codegen/generate.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/npx jsh
+#!/usr/bin/env npx jsh
 
 const rootFolder = require("path").join(__dirname, "../");
 const specFilename = `spec-v1-swagger.json`;

--- a/.swagger-codegen/spec-v1-swagger.json
+++ b/.swagger-codegen/spec-v1-swagger.json
@@ -260,7 +260,7 @@
             "description": "The account to create.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SaveAccountWrapper"
+              "$ref": "#/definitions/PostAccountWrapper"
             }
           }
         ],
@@ -504,7 +504,7 @@
             "description": "The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SaveMonthCategoryWrapper"
+              "$ref": "#/definitions/PatchMonthCategoryWrapper"
             }
           }
         ],
@@ -916,7 +916,7 @@
             "description": "The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SaveTransactionsWrapper"
+              "$ref": "#/definitions/PostTransactionsWrapper"
             }
           }
         ],
@@ -961,7 +961,7 @@
             "description": "The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/UpdateTransactionsWrapper"
+              "$ref": "#/definitions/PatchTransactionsWrapper"
             }
           }
         ],
@@ -1090,7 +1090,7 @@
             "description": "The transaction to update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SaveTransactionWrapper"
+              "$ref": "#/definitions/PutTransactionWrapper"
             }
           }
         ],
@@ -1103,6 +1103,43 @@
           },
           "400": {
             "description": "The request could not be understood due to malformed syntax or validation error(s)",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Transactions"],
+        "summary": "Deletes an existing transaction",
+        "description": "Deletes a transaction",
+        "operationId": "deleteTransaction",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "budget_id",
+            "in": "path",
+            "description": "The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "description": "The id of the transaction",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The transaction was successfully deleted",
+            "schema": {
+              "$ref": "#/definitions/TransactionResponse"
+            }
+          },
+          "404": {
+            "description": "The transaction was not found",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -1848,7 +1885,7 @@
         }
       }
     },
-    "SaveAccountWrapper": {
+    "PostAccountWrapper": {
       "type": "object",
       "required": ["account"],
       "properties": {
@@ -2248,7 +2285,7 @@
         }
       }
     },
-    "SaveTransactionWrapper": {
+    "PutTransactionWrapper": {
       "type": "object",
       "required": ["transaction"],
       "properties": {
@@ -2257,7 +2294,7 @@
         }
       }
     },
-    "SaveTransactionsWrapper": {
+    "PostTransactionsWrapper": {
       "type": "object",
       "properties": {
         "transaction": {
@@ -2271,23 +2308,32 @@
         }
       }
     },
-    "UpdateTransactionsWrapper": {
+    "SaveTransaction": {
+      "allOf": [
+        {
+          "required": ["account_id", "date", "amount"]
+        },
+        {
+          "$ref": "#/definitions/SaveTransactionWithOptionalFields"
+        }
+      ]
+    },
+    "PatchTransactionsWrapper": {
       "type": "object",
       "required": ["transactions"],
       "properties": {
         "transactions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/UpdateTransaction"
+            "$ref": "#/definitions/SaveTransactionWithId"
           }
         }
       }
     },
-    "UpdateTransaction": {
+    "SaveTransactionWithId": {
       "allOf": [
         {
           "type": "object",
-          "required": ["id"],
           "properties": {
             "id": {
               "type": "string"
@@ -2295,13 +2341,12 @@
           }
         },
         {
-          "$ref": "#/definitions/SaveTransaction"
+          "$ref": "#/definitions/SaveTransactionWithOptionalFields"
         }
       ]
     },
-    "SaveTransaction": {
+    "SaveTransactionWithOptionalFields": {
       "type": "object",
-      "required": ["account_id", "date", "amount"],
       "properties": {
         "account_id": {
           "type": "string",
@@ -2512,7 +2557,17 @@
         },
         "import_id": {
           "type": "string",
-          "description": "If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'."
+          "description": "If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'."
+        },
+        "import_payee_name": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules"
+        },
+        "import_payee_name_original": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "If the transaction was imported, the original payee name as it appeared on the statement"
         },
         "deleted": {
           "type": "boolean",
@@ -2580,7 +2635,7 @@
         }
       ]
     },
-    "SaveMonthCategoryWrapper": {
+    "PatchMonthCategoryWrapper": {
       "type": "object",
       "required": ["category"],
       "properties": {

--- a/.swagger-codegen/templates/api.mustache
+++ b/.swagger-codegen/templates/api.mustache
@@ -116,7 +116,8 @@ export const {{classname}}FetchParamCreator = function (configuration: Configura
     {{/allParams}}
             const localVarPath = `{{{path}}}`{{#pathParams}}
                 .replace(`{${"{{baseName}}"}}`, encodeURIComponent({{#isDateTime}}{{paramName}}.toISOString(){{/isDateTime}}{{^isDateTime}}{{#isDate}}convertDateToFullDateStringFormat({{paramName}}){{/isDate}}{{^isDate}}String({{paramName}}){{/isDate}}{{/isDateTime}})){{/pathParams}};
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: '{{httpMethod}}' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -231,9 +232,14 @@ export const {{classname}}FetchParamCreator = function (configuration: Configura
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
     {{/bodyParam}}
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
     {{#hasFormParams}}
             localVarRequestOptions.body = localVarFormParams.toString();
@@ -243,7 +249,7 @@ export const {{classname}}FetchParamCreator = function (configuration: Configura
     {{/bodyParam}}
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -923,6 +923,32 @@ export interface MonthSummary {
 /**
  *
  * @export
+ * @interface PatchMonthCategoryWrapper
+ */
+export interface PatchMonthCategoryWrapper {
+    /**
+     *
+     * @type {SaveMonthCategory}
+     * @memberof PatchMonthCategoryWrapper
+     */
+    category: SaveMonthCategory;
+}
+/**
+ *
+ * @export
+ * @interface PatchTransactionsWrapper
+ */
+export interface PatchTransactionsWrapper {
+    /**
+     *
+     * @type {Array<SaveTransactionWithId>}
+     * @memberof PatchTransactionsWrapper
+     */
+    transactions: Array<SaveTransactionWithId>;
+}
+/**
+ *
+ * @export
  * @interface Payee
  */
 export interface Payee {
@@ -1101,6 +1127,51 @@ export interface PayeesResponseData {
 /**
  *
  * @export
+ * @interface PostAccountWrapper
+ */
+export interface PostAccountWrapper {
+    /**
+     *
+     * @type {SaveAccount}
+     * @memberof PostAccountWrapper
+     */
+    account: SaveAccount;
+}
+/**
+ *
+ * @export
+ * @interface PostTransactionsWrapper
+ */
+export interface PostTransactionsWrapper {
+    /**
+     *
+     * @type {SaveTransaction}
+     * @memberof PostTransactionsWrapper
+     */
+    transaction?: SaveTransaction | null;
+    /**
+     *
+     * @type {Array<SaveTransaction>}
+     * @memberof PostTransactionsWrapper
+     */
+    transactions?: Array<SaveTransaction> | null;
+}
+/**
+ *
+ * @export
+ * @interface PutTransactionWrapper
+ */
+export interface PutTransactionWrapper {
+    /**
+     *
+     * @type {SaveTransaction}
+     * @memberof PutTransactionWrapper
+     */
+    transaction: SaveTransaction;
+}
+/**
+ *
+ * @export
  * @interface SaveAccount
  */
 export interface SaveAccount {
@@ -1122,19 +1193,6 @@ export interface SaveAccount {
      * @memberof SaveAccount
      */
     balance: number;
-}
-/**
- *
- * @export
- * @interface SaveAccountWrapper
- */
-export interface SaveAccountWrapper {
-    /**
-     *
-     * @type {SaveAccount}
-     * @memberof SaveAccountWrapper
-     */
-    account: SaveAccount;
 }
 /**
  *
@@ -1184,19 +1242,6 @@ export interface SaveMonthCategory {
 /**
  *
  * @export
- * @interface SaveMonthCategoryWrapper
- */
-export interface SaveMonthCategoryWrapper {
-    /**
-     *
-     * @type {SaveMonthCategory}
-     * @memberof SaveMonthCategoryWrapper
-     */
-    category: SaveMonthCategory;
-}
-/**
- *
- * @export
  * @interface SaveSubTransaction
  */
 export interface SaveSubTransaction {
@@ -1234,87 +1279,87 @@ export interface SaveSubTransaction {
 /**
  *
  * @export
- * @interface SaveTransaction
+ * @interface SaveTransactionWithOptionalFields
  */
-export interface SaveTransaction {
+export interface SaveTransactionWithOptionalFields {
     /**
      *
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    account_id: string;
+    account_id?: string | null;
     /**
      * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    date: string;
+    date?: string | null;
     /**
      * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
      * @type {number}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    amount: number;
+    amount?: number | null;
     /**
      * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     payee_id?: string | null;
     /**
      * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     payee_name?: string | null;
     /**
      * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     category_id?: string | null;
     /**
      *
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     memo?: string | null;
     /**
      * The cleared status of the transaction
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    cleared?: SaveTransaction.ClearedEnum | null;
+    cleared?: SaveTransactionWithOptionalFields.ClearedEnum | null;
     /**
      * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
      * @type {boolean}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     approved?: boolean | null;
     /**
      * The transaction flag
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    flag_color?: SaveTransaction.FlagColorEnum | null;
+    flag_color?: SaveTransactionWithOptionalFields.FlagColorEnum | null;
     /**
      * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     import_id?: string | null;
     /**
      * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
      * @type {Array<SaveSubTransaction>}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     subtransactions?: Array<SaveSubTransaction> | null;
 }
 /**
  * @export
- * @namespace SaveTransaction
+ * @namespace SaveTransactionWithOptionalFields
  */
-export declare namespace SaveTransaction {
+export declare namespace SaveTransactionWithOptionalFields {
     /**
      * @export
      * @enum {string}
@@ -1336,19 +1381,6 @@ export declare namespace SaveTransaction {
         Blue,
         Purple
     }
-}
-/**
- *
- * @export
- * @interface SaveTransactionWrapper
- */
-export interface SaveTransactionWrapper {
-    /**
-     *
-     * @type {SaveTransaction}
-     * @memberof SaveTransactionWrapper
-     */
-    transaction: SaveTransaction;
 }
 /**
  *
@@ -1399,25 +1431,6 @@ export interface SaveTransactionsResponseData {
      * @memberof SaveTransactionsResponseData
      */
     server_knowledge: number;
-}
-/**
- *
- * @export
- * @interface SaveTransactionsWrapper
- */
-export interface SaveTransactionsWrapper {
-    /**
-     *
-     * @type {SaveTransaction}
-     * @memberof SaveTransactionsWrapper
-     */
-    transaction?: SaveTransaction | null;
-    /**
-     *
-     * @type {Array<SaveTransaction>}
-     * @memberof SaveTransactionsWrapper
-     */
-    transactions?: Array<SaveTransaction> | null;
 }
 /**
  *
@@ -1832,11 +1845,23 @@ export interface TransactionSummary {
      */
     matched_transaction_id?: string | null;
     /**
-     * If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     * If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
      * @type {string}
      * @memberof TransactionSummary
      */
     import_id?: string | null;
+    /**
+     * If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules
+     * @type {string}
+     * @memberof TransactionSummary
+     */
+    import_payee_name?: string | null;
+    /**
+     * If the transaction was imported, the original payee name as it appeared on the statement
+     * @type {string}
+     * @memberof TransactionSummary
+     */
+    import_payee_name_original?: string | null;
     /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
@@ -1928,19 +1953,6 @@ export interface TransactionsResponseData {
      * @memberof TransactionsResponseData
      */
     server_knowledge: number;
-}
-/**
- *
- * @export
- * @interface UpdateTransactionsWrapper
- */
-export interface UpdateTransactionsWrapper {
-    /**
-     *
-     * @type {Array<UpdateTransaction>}
-     * @memberof UpdateTransactionsWrapper
-     */
-    transactions: Array<UpdateTransaction>;
 }
 /**
  *
@@ -2212,11 +2224,23 @@ export interface HybridTransaction {
      */
     matched_transaction_id?: string | null;
     /**
-     * If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     * If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
      * @type {string}
      * @memberof HybridTransaction
      */
     import_id?: string | null;
+    /**
+     * If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules
+     * @type {string}
+     * @memberof HybridTransaction
+     */
+    import_payee_name?: string | null;
+    /**
+     * If the transaction was imported, the original payee name as it appeared on the statement
+     * @type {string}
+     * @memberof HybridTransaction
+     */
+    import_payee_name_original?: string | null;
     /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
@@ -2349,6 +2373,224 @@ export interface MonthDetail {
      * @memberof MonthDetail
      */
     categories: Array<Category>;
+}
+/**
+ *
+ * @export
+ * @interface SaveTransaction
+ */
+export interface SaveTransaction {
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    account_id?: string | null;
+    /**
+     * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    date?: string | null;
+    /**
+     * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
+     * @type {number}
+     * @memberof SaveTransaction
+     */
+    amount?: number | null;
+    /**
+     * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    payee_id?: string | null;
+    /**
+     * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    payee_name?: string | null;
+    /**
+     * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    category_id?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    memo?: string | null;
+    /**
+     * The cleared status of the transaction
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    cleared?: SaveTransaction.ClearedEnum | null;
+    /**
+     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
+     * @type {boolean}
+     * @memberof SaveTransaction
+     */
+    approved?: boolean | null;
+    /**
+     * The transaction flag
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    flag_color?: SaveTransaction.FlagColorEnum | null;
+    /**
+     * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    import_id?: string | null;
+    /**
+     * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
+     * @type {Array<SaveSubTransaction>}
+     * @memberof SaveTransaction
+     */
+    subtransactions?: Array<SaveSubTransaction> | null;
+}
+/**
+ * @export
+ * @namespace SaveTransaction
+ */
+export declare namespace SaveTransaction {
+    /**
+     * @export
+     * @enum {string}
+     */
+    enum ClearedEnum {
+        Cleared,
+        Uncleared,
+        Reconciled
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    enum FlagColorEnum {
+        Red,
+        Orange,
+        Yellow,
+        Green,
+        Blue,
+        Purple
+    }
+}
+/**
+ *
+ * @export
+ * @interface SaveTransactionWithId
+ */
+export interface SaveTransactionWithId {
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    account_id?: string | null;
+    /**
+     * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    date?: string | null;
+    /**
+     * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
+     * @type {number}
+     * @memberof SaveTransactionWithId
+     */
+    amount?: number | null;
+    /**
+     * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    payee_id?: string | null;
+    /**
+     * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    payee_name?: string | null;
+    /**
+     * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    category_id?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    memo?: string | null;
+    /**
+     * The cleared status of the transaction
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    cleared?: SaveTransactionWithId.ClearedEnum | null;
+    /**
+     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
+     * @type {boolean}
+     * @memberof SaveTransactionWithId
+     */
+    approved?: boolean | null;
+    /**
+     * The transaction flag
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    flag_color?: SaveTransactionWithId.FlagColorEnum | null;
+    /**
+     * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    import_id?: string | null;
+    /**
+     * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
+     * @type {Array<SaveSubTransaction>}
+     * @memberof SaveTransactionWithId
+     */
+    subtransactions?: Array<SaveSubTransaction> | null;
+    /**
+     *
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    id?: string | null;
+}
+/**
+ * @export
+ * @namespace SaveTransactionWithId
+ */
+export declare namespace SaveTransactionWithId {
+    /**
+     * @export
+     * @enum {string}
+     */
+    enum ClearedEnum {
+        Cleared,
+        Uncleared,
+        Reconciled
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    enum FlagColorEnum {
+        Red,
+        Orange,
+        Yellow,
+        Green,
+        Blue,
+        Purple
+    }
 }
 /**
  *
@@ -2575,11 +2817,23 @@ export interface TransactionDetail {
      */
     matched_transaction_id?: string | null;
     /**
-     * If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     * If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
      * @type {string}
      * @memberof TransactionDetail
      */
     import_id?: string | null;
+    /**
+     * If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules
+     * @type {string}
+     * @memberof TransactionDetail
+     */
+    import_payee_name?: string | null;
+    /**
+     * If the transaction was imported, the original payee name as it appeared on the statement
+     * @type {string}
+     * @memberof TransactionDetail
+     */
+    import_payee_name_original?: string | null;
     /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
@@ -2639,118 +2893,6 @@ export declare namespace TransactionDetail {
     }
 }
 /**
- *
- * @export
- * @interface UpdateTransaction
- */
-export interface UpdateTransaction {
-    /**
-     *
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    account_id: string;
-    /**
-     * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    date: string;
-    /**
-     * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
-     * @type {number}
-     * @memberof UpdateTransaction
-     */
-    amount: number;
-    /**
-     * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    payee_id?: string | null;
-    /**
-     * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    payee_name?: string | null;
-    /**
-     * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    category_id?: string | null;
-    /**
-     *
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    memo?: string | null;
-    /**
-     * The cleared status of the transaction
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    cleared?: UpdateTransaction.ClearedEnum | null;
-    /**
-     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
-     * @type {boolean}
-     * @memberof UpdateTransaction
-     */
-    approved?: boolean | null;
-    /**
-     * The transaction flag
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    flag_color?: UpdateTransaction.FlagColorEnum | null;
-    /**
-     * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    import_id?: string | null;
-    /**
-     * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
-     * @type {Array<SaveSubTransaction>}
-     * @memberof UpdateTransaction
-     */
-    subtransactions?: Array<SaveSubTransaction> | null;
-    /**
-     *
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    id: string;
-}
-/**
- * @export
- * @namespace UpdateTransaction
- */
-export declare namespace UpdateTransaction {
-    /**
-     * @export
-     * @enum {string}
-     */
-    enum ClearedEnum {
-        Cleared,
-        Uncleared,
-        Reconciled
-    }
-    /**
-     * @export
-     * @enum {string}
-     */
-    enum FlagColorEnum {
-        Red,
-        Orange,
-        Yellow,
-        Green,
-        Blue,
-        Purple
-    }
-}
-/**
  * AccountsApi - fetch parameter creator
  * @export
  */
@@ -2759,11 +2901,11 @@ export declare const AccountsApiFetchParamCreator: (configuration: Configuration
      * Creates a new account
      * @summary Create a new account
      * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-     * @param {SaveAccountWrapper} data - The account to create.
+     * @param {PostAccountWrapper} data - The account to create.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    createAccount(budget_id: string, data: SaveAccountWrapper, options?: any): FetchArgs;
+    createAccount(budget_id: string, data: PostAccountWrapper, options?: any): FetchArgs;
     /**
      * Returns a single account
      * @summary Single account
@@ -2792,11 +2934,11 @@ export declare const AccountsApiFp: (configuration: Configuration) => {
      * Creates a new account
      * @summary Create a new account
      * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-     * @param {SaveAccountWrapper} data - The account to create.
+     * @param {PostAccountWrapper} data - The account to create.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    createAccount(budget_id: string, data: SaveAccountWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<AccountResponse & {
+    createAccount(budget_id: string, data: PostAccountWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<AccountResponse & {
         rateLimit: string | null;
     }>;
     /**
@@ -2831,11 +2973,11 @@ export declare const AccountsApiFactory: (configuration: Configuration) => {
      * Creates a new account
      * @summary Create a new account
      * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-     * @param {SaveAccountWrapper} data - The account to create.
+     * @param {PostAccountWrapper} data - The account to create.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    createAccount(budget_id: string, data: SaveAccountWrapper, options?: any): Promise<AccountResponse & {
+    createAccount(budget_id: string, data: PostAccountWrapper, options?: any): Promise<AccountResponse & {
         rateLimit: string | null;
     }>;
     /**
@@ -2872,12 +3014,12 @@ export declare class AccountsApi extends BaseAPI {
      * Creates a new account
      * @summary Create a new account
      * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-     * @param {SaveAccountWrapper} data - The account to create.
+     * @param {PostAccountWrapper} data - The account to create.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
-    createAccount(budget_id: string, data: SaveAccountWrapper, options?: any): Promise<AccountResponse & {
+    createAccount(budget_id: string, data: PostAccountWrapper, options?: any): Promise<AccountResponse & {
         rateLimit: string | null;
     }>;
     /**
@@ -3091,11 +3233,11 @@ export declare const CategoriesApiFetchParamCreator: (configuration: Configurati
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
      * @param {string} category_id - The id of the category
-     * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+     * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any): FetchArgs;
+    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any): FetchArgs;
 };
 /**
  * CategoriesApi - functional programming interface
@@ -3142,11 +3284,11 @@ export declare const CategoriesApiFp: (configuration: Configuration) => {
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
      * @param {string} category_id - The id of the category
-     * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+     * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<SaveCategoryResponse & {
+    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<SaveCategoryResponse & {
         rateLimit: string | null;
     }>;
 };
@@ -3195,11 +3337,11 @@ export declare const CategoriesApiFactory: (configuration: Configuration) => {
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
      * @param {string} category_id - The id of the category
-     * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+     * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any): Promise<SaveCategoryResponse & {
+    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any): Promise<SaveCategoryResponse & {
         rateLimit: string | null;
     }>;
 };
@@ -3253,12 +3395,12 @@ export declare class CategoriesApi extends BaseAPI {
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
      * @param {string} category_id - The id of the category
-     * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+     * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof CategoriesApi
      */
-    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any): Promise<SaveCategoryResponse & {
+    updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any): Promise<SaveCategoryResponse & {
         rateLimit: string | null;
     }>;
 }
@@ -3827,11 +3969,20 @@ export declare const TransactionsApiFetchParamCreator: (configuration: Configura
      * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+     * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any): FetchArgs;
+    createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any): FetchArgs;
+    /**
+     * Deletes a transaction
+     * @summary Deletes an existing transaction
+     * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+     * @param {string} transaction_id - The id of the transaction
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     */
+    deleteTransaction(budget_id: string, transaction_id: string, options?: any): FetchArgs;
     /**
      * Returns a single transaction
      * @summary Single transaction
@@ -3901,20 +4052,20 @@ export declare const TransactionsApiFetchParamCreator: (configuration: Configura
      * @summary Updates an existing transaction
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {string} transaction_id - The id of the transaction
-     * @param {SaveTransactionWrapper} data - The transaction to update
+     * @param {PutTransactionWrapper} data - The transaction to update
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any): FetchArgs;
+    updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any): FetchArgs;
     /**
      * Updates multiple transactions, by `id` or `import_id`.
      * @summary Update multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+     * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any): FetchArgs;
+    updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any): FetchArgs;
 };
 /**
  * TransactionsApi - functional programming interface
@@ -3925,11 +4076,22 @@ export declare const TransactionsApiFp: (configuration: Configuration) => {
      * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+     * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<SaveTransactionsResponse & {
+    createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<SaveTransactionsResponse & {
+        rateLimit: string | null;
+    }>;
+    /**
+     * Deletes a transaction
+     * @summary Deletes an existing transaction
+     * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+     * @param {string} transaction_id - The id of the transaction
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     */
+    deleteTransaction(budget_id: string, transaction_id: string, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<TransactionResponse & {
         rateLimit: string | null;
     }>;
     /**
@@ -4013,22 +4175,22 @@ export declare const TransactionsApiFp: (configuration: Configuration) => {
      * @summary Updates an existing transaction
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {string} transaction_id - The id of the transaction
-     * @param {SaveTransactionWrapper} data - The transaction to update
+     * @param {PutTransactionWrapper} data - The transaction to update
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<TransactionResponse & {
+    updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<TransactionResponse & {
         rateLimit: string | null;
     }>;
     /**
      * Updates multiple transactions, by `id` or `import_id`.
      * @summary Update multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+     * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<SaveTransactionsResponse & {
+    updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI | undefined) => Promise<SaveTransactionsResponse & {
         rateLimit: string | null;
     }>;
 };
@@ -4041,11 +4203,22 @@ export declare const TransactionsApiFactory: (configuration: Configuration) => {
      * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+     * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
+    createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
+        rateLimit: string | null;
+    }>;
+    /**
+     * Deletes a transaction
+     * @summary Deletes an existing transaction
+     * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+     * @param {string} transaction_id - The id of the transaction
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     */
+    deleteTransaction(budget_id: string, transaction_id: string, options?: any): Promise<TransactionResponse & {
         rateLimit: string | null;
     }>;
     /**
@@ -4129,22 +4302,22 @@ export declare const TransactionsApiFactory: (configuration: Configuration) => {
      * @summary Updates an existing transaction
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {string} transaction_id - The id of the transaction
-     * @param {SaveTransactionWrapper} data - The transaction to update
+     * @param {PutTransactionWrapper} data - The transaction to update
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any): Promise<TransactionResponse & {
+    updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any): Promise<TransactionResponse & {
         rateLimit: string | null;
     }>;
     /**
      * Updates multiple transactions, by `id` or `import_id`.
      * @summary Update multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+     * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      */
-    updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
+    updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
         rateLimit: string | null;
     }>;
 };
@@ -4159,12 +4332,24 @@ export declare class TransactionsApi extends BaseAPI {
      * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+     * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
+    createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
+        rateLimit: string | null;
+    }>;
+    /**
+     * Deletes a transaction
+     * @summary Deletes an existing transaction
+     * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+     * @param {string} transaction_id - The id of the transaction
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    deleteTransaction(budget_id: string, transaction_id: string, options?: any): Promise<TransactionResponse & {
         rateLimit: string | null;
     }>;
     /**
@@ -4254,24 +4439,24 @@ export declare class TransactionsApi extends BaseAPI {
      * @summary Updates an existing transaction
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {string} transaction_id - The id of the transaction
-     * @param {SaveTransactionWrapper} data - The transaction to update
+     * @param {PutTransactionWrapper} data - The transaction to update
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any): Promise<TransactionResponse & {
+    updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any): Promise<TransactionResponse & {
         rateLimit: string | null;
     }>;
     /**
      * Updates multiple transactions, by `id` or `import_id`.
      * @summary Update multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+     * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
+    updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any): Promise<SaveTransactionsResponse & {
         rateLimit: string | null;
     }>;
 }

--- a/dist/api.js
+++ b/dist/api.js
@@ -21,7 +21,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.UserApi = exports.UserApiFactory = exports.UserApiFp = exports.UserApiFetchParamCreator = exports.TransactionsApi = exports.TransactionsApiFactory = exports.TransactionsApiFp = exports.TransactionsApiFetchParamCreator = exports.ScheduledTransactionsApi = exports.ScheduledTransactionsApiFactory = exports.ScheduledTransactionsApiFp = exports.ScheduledTransactionsApiFetchParamCreator = exports.PayeesApi = exports.PayeesApiFactory = exports.PayeesApiFp = exports.PayeesApiFetchParamCreator = exports.PayeeLocationsApi = exports.PayeeLocationsApiFactory = exports.PayeeLocationsApiFp = exports.PayeeLocationsApiFetchParamCreator = exports.MonthsApi = exports.MonthsApiFactory = exports.MonthsApiFp = exports.MonthsApiFetchParamCreator = exports.DeprecatedApi = exports.DeprecatedApiFactory = exports.DeprecatedApiFp = exports.DeprecatedApiFetchParamCreator = exports.CategoriesApi = exports.CategoriesApiFactory = exports.CategoriesApiFp = exports.CategoriesApiFetchParamCreator = exports.BudgetsApi = exports.BudgetsApiFactory = exports.BudgetsApiFp = exports.BudgetsApiFetchParamCreator = exports.AccountsApi = exports.AccountsApiFactory = exports.AccountsApiFp = exports.AccountsApiFetchParamCreator = exports.UpdateTransaction = exports.TransactionDetail = exports.ScheduledTransactionDetail = exports.HybridTransaction = exports.TransactionSummary = exports.ScheduledTransactionSummary = exports.SaveTransaction = exports.Category = exports.AccountType = exports.RequiredError = exports.BaseAPI = exports.COLLECTION_FORMATS = void 0;
+exports.UserApiFetchParamCreator = exports.TransactionsApi = exports.TransactionsApiFactory = exports.TransactionsApiFp = exports.TransactionsApiFetchParamCreator = exports.ScheduledTransactionsApi = exports.ScheduledTransactionsApiFactory = exports.ScheduledTransactionsApiFp = exports.ScheduledTransactionsApiFetchParamCreator = exports.PayeesApi = exports.PayeesApiFactory = exports.PayeesApiFp = exports.PayeesApiFetchParamCreator = exports.PayeeLocationsApi = exports.PayeeLocationsApiFactory = exports.PayeeLocationsApiFp = exports.PayeeLocationsApiFetchParamCreator = exports.MonthsApi = exports.MonthsApiFactory = exports.MonthsApiFp = exports.MonthsApiFetchParamCreator = exports.DeprecatedApi = exports.DeprecatedApiFactory = exports.DeprecatedApiFp = exports.DeprecatedApiFetchParamCreator = exports.CategoriesApi = exports.CategoriesApiFactory = exports.CategoriesApiFp = exports.CategoriesApiFetchParamCreator = exports.BudgetsApi = exports.BudgetsApiFactory = exports.BudgetsApiFp = exports.BudgetsApiFetchParamCreator = exports.AccountsApi = exports.AccountsApiFactory = exports.AccountsApiFp = exports.AccountsApiFetchParamCreator = exports.TransactionDetail = exports.ScheduledTransactionDetail = exports.SaveTransactionWithId = exports.SaveTransaction = exports.HybridTransaction = exports.TransactionSummary = exports.ScheduledTransactionSummary = exports.SaveTransactionWithOptionalFields = exports.Category = exports.AccountType = exports.RequiredError = exports.BaseAPI = exports.COLLECTION_FORMATS = void 0;
+exports.UserApi = exports.UserApiFactory = exports.UserApiFp = void 0;
 // Polyfill fetch globally - this makes it easier to override with modules like fetch-mock.
 const fetchPonyfill = require("fetch-ponyfill")();
 if (!globalThis.fetch) {
@@ -30,8 +31,7 @@ if (!globalThis.fetch) {
     globalThis.Headers = fetchPonyfill.Headers;
     globalThis.Request = fetchPonyfill.Request;
 }
-const url = require("url");
-const USER_AGENT = "api_client/js/1.32.0";
+const USER_AGENT = "api_client/js/1.42.0";
 function convertDateToFullDateStringFormat(date) {
     // Convert to RFC 3339 "full-date" format, like "2017-11-27"
     if (date instanceof Date) {
@@ -120,10 +120,10 @@ var Category;
 })(Category = exports.Category || (exports.Category = {}));
 /**
  * @export
- * @namespace SaveTransaction
+ * @namespace SaveTransactionWithOptionalFields
  */
-var SaveTransaction;
-(function (SaveTransaction) {
+var SaveTransactionWithOptionalFields;
+(function (SaveTransactionWithOptionalFields) {
     /**
      * @export
      * @enum {string}
@@ -133,7 +133,7 @@ var SaveTransaction;
         ClearedEnum[ClearedEnum["Cleared"] = 'cleared'] = "Cleared";
         ClearedEnum[ClearedEnum["Uncleared"] = 'uncleared'] = "Uncleared";
         ClearedEnum[ClearedEnum["Reconciled"] = 'reconciled'] = "Reconciled";
-    })(ClearedEnum = SaveTransaction.ClearedEnum || (SaveTransaction.ClearedEnum = {}));
+    })(ClearedEnum = SaveTransactionWithOptionalFields.ClearedEnum || (SaveTransactionWithOptionalFields.ClearedEnum = {}));
     /**
      * @export
      * @enum {string}
@@ -146,8 +146,8 @@ var SaveTransaction;
         FlagColorEnum[FlagColorEnum["Green"] = 'green'] = "Green";
         FlagColorEnum[FlagColorEnum["Blue"] = 'blue'] = "Blue";
         FlagColorEnum[FlagColorEnum["Purple"] = 'purple'] = "Purple";
-    })(FlagColorEnum = SaveTransaction.FlagColorEnum || (SaveTransaction.FlagColorEnum = {}));
-})(SaveTransaction = exports.SaveTransaction || (exports.SaveTransaction = {}));
+    })(FlagColorEnum = SaveTransactionWithOptionalFields.FlagColorEnum || (SaveTransactionWithOptionalFields.FlagColorEnum = {}));
+})(SaveTransactionWithOptionalFields = exports.SaveTransactionWithOptionalFields || (exports.SaveTransactionWithOptionalFields = {}));
 /**
  * @export
  * @namespace ScheduledTransactionSummary
@@ -259,6 +259,66 @@ var HybridTransaction;
 })(HybridTransaction = exports.HybridTransaction || (exports.HybridTransaction = {}));
 /**
  * @export
+ * @namespace SaveTransaction
+ */
+var SaveTransaction;
+(function (SaveTransaction) {
+    /**
+     * @export
+     * @enum {string}
+     */
+    let ClearedEnum;
+    (function (ClearedEnum) {
+        ClearedEnum[ClearedEnum["Cleared"] = 'cleared'] = "Cleared";
+        ClearedEnum[ClearedEnum["Uncleared"] = 'uncleared'] = "Uncleared";
+        ClearedEnum[ClearedEnum["Reconciled"] = 'reconciled'] = "Reconciled";
+    })(ClearedEnum = SaveTransaction.ClearedEnum || (SaveTransaction.ClearedEnum = {}));
+    /**
+     * @export
+     * @enum {string}
+     */
+    let FlagColorEnum;
+    (function (FlagColorEnum) {
+        FlagColorEnum[FlagColorEnum["Red"] = 'red'] = "Red";
+        FlagColorEnum[FlagColorEnum["Orange"] = 'orange'] = "Orange";
+        FlagColorEnum[FlagColorEnum["Yellow"] = 'yellow'] = "Yellow";
+        FlagColorEnum[FlagColorEnum["Green"] = 'green'] = "Green";
+        FlagColorEnum[FlagColorEnum["Blue"] = 'blue'] = "Blue";
+        FlagColorEnum[FlagColorEnum["Purple"] = 'purple'] = "Purple";
+    })(FlagColorEnum = SaveTransaction.FlagColorEnum || (SaveTransaction.FlagColorEnum = {}));
+})(SaveTransaction = exports.SaveTransaction || (exports.SaveTransaction = {}));
+/**
+ * @export
+ * @namespace SaveTransactionWithId
+ */
+var SaveTransactionWithId;
+(function (SaveTransactionWithId) {
+    /**
+     * @export
+     * @enum {string}
+     */
+    let ClearedEnum;
+    (function (ClearedEnum) {
+        ClearedEnum[ClearedEnum["Cleared"] = 'cleared'] = "Cleared";
+        ClearedEnum[ClearedEnum["Uncleared"] = 'uncleared'] = "Uncleared";
+        ClearedEnum[ClearedEnum["Reconciled"] = 'reconciled'] = "Reconciled";
+    })(ClearedEnum = SaveTransactionWithId.ClearedEnum || (SaveTransactionWithId.ClearedEnum = {}));
+    /**
+     * @export
+     * @enum {string}
+     */
+    let FlagColorEnum;
+    (function (FlagColorEnum) {
+        FlagColorEnum[FlagColorEnum["Red"] = 'red'] = "Red";
+        FlagColorEnum[FlagColorEnum["Orange"] = 'orange'] = "Orange";
+        FlagColorEnum[FlagColorEnum["Yellow"] = 'yellow'] = "Yellow";
+        FlagColorEnum[FlagColorEnum["Green"] = 'green'] = "Green";
+        FlagColorEnum[FlagColorEnum["Blue"] = 'blue'] = "Blue";
+        FlagColorEnum[FlagColorEnum["Purple"] = 'purple'] = "Purple";
+    })(FlagColorEnum = SaveTransactionWithId.FlagColorEnum || (SaveTransactionWithId.FlagColorEnum = {}));
+})(SaveTransactionWithId = exports.SaveTransactionWithId || (exports.SaveTransactionWithId = {}));
+/**
+ * @export
  * @namespace ScheduledTransactionDetail
  */
 var ScheduledTransactionDetail;
@@ -328,46 +388,16 @@ var TransactionDetail;
     })(FlagColorEnum = TransactionDetail.FlagColorEnum || (TransactionDetail.FlagColorEnum = {}));
 })(TransactionDetail = exports.TransactionDetail || (exports.TransactionDetail = {}));
 /**
- * @export
- * @namespace UpdateTransaction
- */
-var UpdateTransaction;
-(function (UpdateTransaction) {
-    /**
-     * @export
-     * @enum {string}
-     */
-    let ClearedEnum;
-    (function (ClearedEnum) {
-        ClearedEnum[ClearedEnum["Cleared"] = 'cleared'] = "Cleared";
-        ClearedEnum[ClearedEnum["Uncleared"] = 'uncleared'] = "Uncleared";
-        ClearedEnum[ClearedEnum["Reconciled"] = 'reconciled'] = "Reconciled";
-    })(ClearedEnum = UpdateTransaction.ClearedEnum || (UpdateTransaction.ClearedEnum = {}));
-    /**
-     * @export
-     * @enum {string}
-     */
-    let FlagColorEnum;
-    (function (FlagColorEnum) {
-        FlagColorEnum[FlagColorEnum["Red"] = 'red'] = "Red";
-        FlagColorEnum[FlagColorEnum["Orange"] = 'orange'] = "Orange";
-        FlagColorEnum[FlagColorEnum["Yellow"] = 'yellow'] = "Yellow";
-        FlagColorEnum[FlagColorEnum["Green"] = 'green'] = "Green";
-        FlagColorEnum[FlagColorEnum["Blue"] = 'blue'] = "Blue";
-        FlagColorEnum[FlagColorEnum["Purple"] = 'purple'] = "Purple";
-    })(FlagColorEnum = UpdateTransaction.FlagColorEnum || (UpdateTransaction.FlagColorEnum = {}));
-})(UpdateTransaction = exports.UpdateTransaction || (exports.UpdateTransaction = {}));
-/**
  * AccountsApi - fetch parameter creator
  * @export
  */
-exports.AccountsApiFetchParamCreator = function (configuration) {
+const AccountsApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Creates a new account
          * @summary Create a new account
          * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-         * @param {SaveAccountWrapper} data - The account to create.
+         * @param {PostAccountWrapper} data - The account to create.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
@@ -382,7 +412,8 @@ exports.AccountsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/accounts`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -394,13 +425,18 @@ exports.AccountsApiFetchParamCreator = function (configuration) {
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
             localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -424,7 +460,8 @@ exports.AccountsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/accounts/{account_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"account_id"}}`, encodeURIComponent(String(account_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -435,12 +472,17 @@ exports.AccountsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -459,7 +501,8 @@ exports.AccountsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/accounts`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -473,33 +516,39 @@ exports.AccountsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.AccountsApiFetchParamCreator = AccountsApiFetchParamCreator;
 /**
  * AccountsApi - functional programming interface
  * @export
  */
-exports.AccountsApiFp = function (configuration) {
+const AccountsApiFp = function (configuration) {
     return {
         /**
          * Creates a new account
          * @summary Create a new account
          * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-         * @param {SaveAccountWrapper} data - The account to create.
+         * @param {PostAccountWrapper} data - The account to create.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         createAccount(budget_id, data, options) {
-            const localVarFetchArgs = exports.AccountsApiFetchParamCreator(configuration).createAccount(budget_id, data, options);
+            const localVarFetchArgs = (0, exports.AccountsApiFetchParamCreator)(configuration).createAccount(budget_id, data, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -524,7 +573,7 @@ exports.AccountsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getAccountById(budget_id, account_id, options) {
-            const localVarFetchArgs = exports.AccountsApiFetchParamCreator(configuration).getAccountById(budget_id, account_id, options);
+            const localVarFetchArgs = (0, exports.AccountsApiFetchParamCreator)(configuration).getAccountById(budget_id, account_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -549,7 +598,7 @@ exports.AccountsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getAccounts(budget_id, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.AccountsApiFetchParamCreator(configuration).getAccounts(budget_id, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.AccountsApiFetchParamCreator)(configuration).getAccounts(budget_id, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -567,22 +616,23 @@ exports.AccountsApiFp = function (configuration) {
         },
     };
 };
+exports.AccountsApiFp = AccountsApiFp;
 /**
  * AccountsApi - factory interface
  * @export
  */
-exports.AccountsApiFactory = function (configuration) {
+const AccountsApiFactory = function (configuration) {
     return {
         /**
          * Creates a new account
          * @summary Create a new account
          * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-         * @param {SaveAccountWrapper} data - The account to create.
+         * @param {PostAccountWrapper} data - The account to create.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         createAccount(budget_id, data, options) {
-            return exports.AccountsApiFp(configuration).createAccount(budget_id, data, options)();
+            return (0, exports.AccountsApiFp)(configuration).createAccount(budget_id, data, options)();
         },
         /**
          * Returns a single account
@@ -593,7 +643,7 @@ exports.AccountsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getAccountById(budget_id, account_id, options) {
-            return exports.AccountsApiFp(configuration).getAccountById(budget_id, account_id, options)();
+            return (0, exports.AccountsApiFp)(configuration).getAccountById(budget_id, account_id, options)();
         },
         /**
          * Returns all accounts
@@ -604,10 +654,11 @@ exports.AccountsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getAccounts(budget_id, last_knowledge_of_server, options) {
-            return exports.AccountsApiFp(configuration).getAccounts(budget_id, last_knowledge_of_server, options)();
+            return (0, exports.AccountsApiFp)(configuration).getAccounts(budget_id, last_knowledge_of_server, options)();
         },
     };
 };
+exports.AccountsApiFactory = AccountsApiFactory;
 /**
  * AccountsApi - object-oriented interface
  * @export
@@ -619,13 +670,13 @@ class AccountsApi extends BaseAPI {
      * Creates a new account
      * @summary Create a new account
      * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-     * @param {SaveAccountWrapper} data - The account to create.
+     * @param {PostAccountWrapper} data - The account to create.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
     createAccount(budget_id, data, options) {
-        return exports.AccountsApiFp(this.configuration).createAccount(budget_id, data, options)();
+        return (0, exports.AccountsApiFp)(this.configuration).createAccount(budget_id, data, options)();
     }
     /**
      * Returns a single account
@@ -637,7 +688,7 @@ class AccountsApi extends BaseAPI {
      * @memberof AccountsApi
      */
     getAccountById(budget_id, account_id, options) {
-        return exports.AccountsApiFp(this.configuration).getAccountById(budget_id, account_id, options)();
+        return (0, exports.AccountsApiFp)(this.configuration).getAccountById(budget_id, account_id, options)();
     }
     /**
      * Returns all accounts
@@ -649,7 +700,7 @@ class AccountsApi extends BaseAPI {
      * @memberof AccountsApi
      */
     getAccounts(budget_id, last_knowledge_of_server, options) {
-        return exports.AccountsApiFp(this.configuration).getAccounts(budget_id, last_knowledge_of_server, options)();
+        return (0, exports.AccountsApiFp)(this.configuration).getAccounts(budget_id, last_knowledge_of_server, options)();
     }
 }
 exports.AccountsApi = AccountsApi;
@@ -657,7 +708,7 @@ exports.AccountsApi = AccountsApi;
  * BudgetsApi - fetch parameter creator
  * @export
  */
-exports.BudgetsApiFetchParamCreator = function (configuration) {
+const BudgetsApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns a single budget with all related entities.  This resource is effectively a full budget export.
@@ -674,7 +725,8 @@ exports.BudgetsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -688,12 +740,17 @@ exports.BudgetsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -711,7 +768,8 @@ exports.BudgetsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/settings`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -722,12 +780,17 @@ exports.BudgetsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -740,7 +803,8 @@ exports.BudgetsApiFetchParamCreator = function (configuration) {
          */
         getBudgets(include_accounts, options = {}) {
             const localVarPath = `/budgets`;
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -754,22 +818,28 @@ exports.BudgetsApiFetchParamCreator = function (configuration) {
             if (include_accounts !== undefined) {
                 localVarQueryParameter['include_accounts'] = include_accounts;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.BudgetsApiFetchParamCreator = BudgetsApiFetchParamCreator;
 /**
  * BudgetsApi - functional programming interface
  * @export
  */
-exports.BudgetsApiFp = function (configuration) {
+const BudgetsApiFp = function (configuration) {
     return {
         /**
          * Returns a single budget with all related entities.  This resource is effectively a full budget export.
@@ -780,7 +850,7 @@ exports.BudgetsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetById(budget_id, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.BudgetsApiFetchParamCreator(configuration).getBudgetById(budget_id, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.BudgetsApiFetchParamCreator)(configuration).getBudgetById(budget_id, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -804,7 +874,7 @@ exports.BudgetsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetSettingsById(budget_id, options) {
-            const localVarFetchArgs = exports.BudgetsApiFetchParamCreator(configuration).getBudgetSettingsById(budget_id, options);
+            const localVarFetchArgs = (0, exports.BudgetsApiFetchParamCreator)(configuration).getBudgetSettingsById(budget_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -828,7 +898,7 @@ exports.BudgetsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgets(include_accounts, options) {
-            const localVarFetchArgs = exports.BudgetsApiFetchParamCreator(configuration).getBudgets(include_accounts, options);
+            const localVarFetchArgs = (0, exports.BudgetsApiFetchParamCreator)(configuration).getBudgets(include_accounts, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -846,11 +916,12 @@ exports.BudgetsApiFp = function (configuration) {
         },
     };
 };
+exports.BudgetsApiFp = BudgetsApiFp;
 /**
  * BudgetsApi - factory interface
  * @export
  */
-exports.BudgetsApiFactory = function (configuration) {
+const BudgetsApiFactory = function (configuration) {
     return {
         /**
          * Returns a single budget with all related entities.  This resource is effectively a full budget export.
@@ -861,7 +932,7 @@ exports.BudgetsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetById(budget_id, last_knowledge_of_server, options) {
-            return exports.BudgetsApiFp(configuration).getBudgetById(budget_id, last_knowledge_of_server, options)();
+            return (0, exports.BudgetsApiFp)(configuration).getBudgetById(budget_id, last_knowledge_of_server, options)();
         },
         /**
          * Returns settings for a budget
@@ -871,7 +942,7 @@ exports.BudgetsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetSettingsById(budget_id, options) {
-            return exports.BudgetsApiFp(configuration).getBudgetSettingsById(budget_id, options)();
+            return (0, exports.BudgetsApiFp)(configuration).getBudgetSettingsById(budget_id, options)();
         },
         /**
          * Returns budgets list with summary information
@@ -881,10 +952,11 @@ exports.BudgetsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgets(include_accounts, options) {
-            return exports.BudgetsApiFp(configuration).getBudgets(include_accounts, options)();
+            return (0, exports.BudgetsApiFp)(configuration).getBudgets(include_accounts, options)();
         },
     };
 };
+exports.BudgetsApiFactory = BudgetsApiFactory;
 /**
  * BudgetsApi - object-oriented interface
  * @export
@@ -902,7 +974,7 @@ class BudgetsApi extends BaseAPI {
      * @memberof BudgetsApi
      */
     getBudgetById(budget_id, last_knowledge_of_server, options) {
-        return exports.BudgetsApiFp(this.configuration).getBudgetById(budget_id, last_knowledge_of_server, options)();
+        return (0, exports.BudgetsApiFp)(this.configuration).getBudgetById(budget_id, last_knowledge_of_server, options)();
     }
     /**
      * Returns settings for a budget
@@ -913,7 +985,7 @@ class BudgetsApi extends BaseAPI {
      * @memberof BudgetsApi
      */
     getBudgetSettingsById(budget_id, options) {
-        return exports.BudgetsApiFp(this.configuration).getBudgetSettingsById(budget_id, options)();
+        return (0, exports.BudgetsApiFp)(this.configuration).getBudgetSettingsById(budget_id, options)();
     }
     /**
      * Returns budgets list with summary information
@@ -924,7 +996,7 @@ class BudgetsApi extends BaseAPI {
      * @memberof BudgetsApi
      */
     getBudgets(include_accounts, options) {
-        return exports.BudgetsApiFp(this.configuration).getBudgets(include_accounts, options)();
+        return (0, exports.BudgetsApiFp)(this.configuration).getBudgets(include_accounts, options)();
     }
 }
 exports.BudgetsApi = BudgetsApi;
@@ -932,7 +1004,7 @@ exports.BudgetsApi = BudgetsApi;
  * CategoriesApi - fetch parameter creator
  * @export
  */
-exports.CategoriesApiFetchParamCreator = function (configuration) {
+const CategoriesApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns all categories grouped by category group.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -949,7 +1021,8 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/categories`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -963,12 +1036,17 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -992,7 +1070,8 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/categories/{category_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1003,12 +1082,17 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -1038,7 +1122,8 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"month"}}`, encodeURIComponent(convertDateToFullDateStringFormat(month)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1049,12 +1134,17 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -1064,7 +1154,7 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
          * @param {string} category_id - The id of the category
-         * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+         * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
@@ -1089,7 +1179,8 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"month"}}`, encodeURIComponent(convertDateToFullDateStringFormat(month)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'PATCH' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1101,23 +1192,29 @@ exports.CategoriesApiFetchParamCreator = function (configuration) {
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
             localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.CategoriesApiFetchParamCreator = CategoriesApiFetchParamCreator;
 /**
  * CategoriesApi - functional programming interface
  * @export
  */
-exports.CategoriesApiFp = function (configuration) {
+const CategoriesApiFp = function (configuration) {
     return {
         /**
          * Returns all categories grouped by category group.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -1128,7 +1225,7 @@ exports.CategoriesApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getCategories(budget_id, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.CategoriesApiFetchParamCreator(configuration).getCategories(budget_id, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.CategoriesApiFetchParamCreator)(configuration).getCategories(budget_id, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1153,7 +1250,7 @@ exports.CategoriesApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getCategoryById(budget_id, category_id, options) {
-            const localVarFetchArgs = exports.CategoriesApiFetchParamCreator(configuration).getCategoryById(budget_id, category_id, options);
+            const localVarFetchArgs = (0, exports.CategoriesApiFetchParamCreator)(configuration).getCategoryById(budget_id, category_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1179,7 +1276,7 @@ exports.CategoriesApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getMonthCategoryById(budget_id, month, category_id, options) {
-            const localVarFetchArgs = exports.CategoriesApiFetchParamCreator(configuration).getMonthCategoryById(budget_id, month, category_id, options);
+            const localVarFetchArgs = (0, exports.CategoriesApiFetchParamCreator)(configuration).getMonthCategoryById(budget_id, month, category_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1201,12 +1298,12 @@ exports.CategoriesApiFp = function (configuration) {
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
          * @param {string} category_id - The id of the category
-         * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+         * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         updateMonthCategory(budget_id, month, category_id, data, options) {
-            const localVarFetchArgs = exports.CategoriesApiFetchParamCreator(configuration).updateMonthCategory(budget_id, month, category_id, data, options);
+            const localVarFetchArgs = (0, exports.CategoriesApiFetchParamCreator)(configuration).updateMonthCategory(budget_id, month, category_id, data, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1224,11 +1321,12 @@ exports.CategoriesApiFp = function (configuration) {
         },
     };
 };
+exports.CategoriesApiFp = CategoriesApiFp;
 /**
  * CategoriesApi - factory interface
  * @export
  */
-exports.CategoriesApiFactory = function (configuration) {
+const CategoriesApiFactory = function (configuration) {
     return {
         /**
          * Returns all categories grouped by category group.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -1239,7 +1337,7 @@ exports.CategoriesApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getCategories(budget_id, last_knowledge_of_server, options) {
-            return exports.CategoriesApiFp(configuration).getCategories(budget_id, last_knowledge_of_server, options)();
+            return (0, exports.CategoriesApiFp)(configuration).getCategories(budget_id, last_knowledge_of_server, options)();
         },
         /**
          * Returns a single category.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -1250,7 +1348,7 @@ exports.CategoriesApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getCategoryById(budget_id, category_id, options) {
-            return exports.CategoriesApiFp(configuration).getCategoryById(budget_id, category_id, options)();
+            return (0, exports.CategoriesApiFp)(configuration).getCategoryById(budget_id, category_id, options)();
         },
         /**
          * Returns a single category for a specific budget month.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -1262,7 +1360,7 @@ exports.CategoriesApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getMonthCategoryById(budget_id, month, category_id, options) {
-            return exports.CategoriesApiFp(configuration).getMonthCategoryById(budget_id, month, category_id, options)();
+            return (0, exports.CategoriesApiFp)(configuration).getMonthCategoryById(budget_id, month, category_id, options)();
         },
         /**
          * Update a category for a specific month.  Only `budgeted` amount can be updated.
@@ -1270,15 +1368,16 @@ exports.CategoriesApiFactory = function (configuration) {
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
          * @param {string} category_id - The id of the category
-         * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+         * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         updateMonthCategory(budget_id, month, category_id, data, options) {
-            return exports.CategoriesApiFp(configuration).updateMonthCategory(budget_id, month, category_id, data, options)();
+            return (0, exports.CategoriesApiFp)(configuration).updateMonthCategory(budget_id, month, category_id, data, options)();
         },
     };
 };
+exports.CategoriesApiFactory = CategoriesApiFactory;
 /**
  * CategoriesApi - object-oriented interface
  * @export
@@ -1296,7 +1395,7 @@ class CategoriesApi extends BaseAPI {
      * @memberof CategoriesApi
      */
     getCategories(budget_id, last_knowledge_of_server, options) {
-        return exports.CategoriesApiFp(this.configuration).getCategories(budget_id, last_knowledge_of_server, options)();
+        return (0, exports.CategoriesApiFp)(this.configuration).getCategories(budget_id, last_knowledge_of_server, options)();
     }
     /**
      * Returns a single category.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -1308,7 +1407,7 @@ class CategoriesApi extends BaseAPI {
      * @memberof CategoriesApi
      */
     getCategoryById(budget_id, category_id, options) {
-        return exports.CategoriesApiFp(this.configuration).getCategoryById(budget_id, category_id, options)();
+        return (0, exports.CategoriesApiFp)(this.configuration).getCategoryById(budget_id, category_id, options)();
     }
     /**
      * Returns a single category for a specific budget month.  Amounts (budgeted, activity, balance, etc.) are specific to the current budget month (UTC).
@@ -1321,7 +1420,7 @@ class CategoriesApi extends BaseAPI {
      * @memberof CategoriesApi
      */
     getMonthCategoryById(budget_id, month, category_id, options) {
-        return exports.CategoriesApiFp(this.configuration).getMonthCategoryById(budget_id, month, category_id, options)();
+        return (0, exports.CategoriesApiFp)(this.configuration).getMonthCategoryById(budget_id, month, category_id, options)();
     }
     /**
      * Update a category for a specific month.  Only `budgeted` amount can be updated.
@@ -1329,13 +1428,13 @@ class CategoriesApi extends BaseAPI {
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
      * @param {string} category_id - The id of the category
-     * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+     * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof CategoriesApi
      */
     updateMonthCategory(budget_id, month, category_id, data, options) {
-        return exports.CategoriesApiFp(this.configuration).updateMonthCategory(budget_id, month, category_id, data, options)();
+        return (0, exports.CategoriesApiFp)(this.configuration).updateMonthCategory(budget_id, month, category_id, data, options)();
     }
 }
 exports.CategoriesApi = CategoriesApi;
@@ -1343,7 +1442,7 @@ exports.CategoriesApi = CategoriesApi;
  * DeprecatedApi - fetch parameter creator
  * @export
  */
-exports.DeprecatedApiFetchParamCreator = function (configuration) {
+const DeprecatedApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Creates multiple transactions.  Although this endpoint is still supported, it is recommended to use 'POST /budgets/{budget_id}/transactions' to create multiple transactions.
@@ -1364,7 +1463,8 @@ exports.DeprecatedApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/transactions/bulk`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1376,23 +1476,29 @@ exports.DeprecatedApiFetchParamCreator = function (configuration) {
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
             localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(transactions || {});
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.DeprecatedApiFetchParamCreator = DeprecatedApiFetchParamCreator;
 /**
  * DeprecatedApi - functional programming interface
  * @export
  */
-exports.DeprecatedApiFp = function (configuration) {
+const DeprecatedApiFp = function (configuration) {
     return {
         /**
          * Creates multiple transactions.  Although this endpoint is still supported, it is recommended to use 'POST /budgets/{budget_id}/transactions' to create multiple transactions.
@@ -1403,7 +1509,7 @@ exports.DeprecatedApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         bulkCreateTransactions(budget_id, transactions, options) {
-            const localVarFetchArgs = exports.DeprecatedApiFetchParamCreator(configuration).bulkCreateTransactions(budget_id, transactions, options);
+            const localVarFetchArgs = (0, exports.DeprecatedApiFetchParamCreator)(configuration).bulkCreateTransactions(budget_id, transactions, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1421,11 +1527,12 @@ exports.DeprecatedApiFp = function (configuration) {
         },
     };
 };
+exports.DeprecatedApiFp = DeprecatedApiFp;
 /**
  * DeprecatedApi - factory interface
  * @export
  */
-exports.DeprecatedApiFactory = function (configuration) {
+const DeprecatedApiFactory = function (configuration) {
     return {
         /**
          * Creates multiple transactions.  Although this endpoint is still supported, it is recommended to use 'POST /budgets/{budget_id}/transactions' to create multiple transactions.
@@ -1436,10 +1543,11 @@ exports.DeprecatedApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         bulkCreateTransactions(budget_id, transactions, options) {
-            return exports.DeprecatedApiFp(configuration).bulkCreateTransactions(budget_id, transactions, options)();
+            return (0, exports.DeprecatedApiFp)(configuration).bulkCreateTransactions(budget_id, transactions, options)();
         },
     };
 };
+exports.DeprecatedApiFactory = DeprecatedApiFactory;
 /**
  * DeprecatedApi - object-oriented interface
  * @export
@@ -1457,7 +1565,7 @@ class DeprecatedApi extends BaseAPI {
      * @memberof DeprecatedApi
      */
     bulkCreateTransactions(budget_id, transactions, options) {
-        return exports.DeprecatedApiFp(this.configuration).bulkCreateTransactions(budget_id, transactions, options)();
+        return (0, exports.DeprecatedApiFp)(this.configuration).bulkCreateTransactions(budget_id, transactions, options)();
     }
 }
 exports.DeprecatedApi = DeprecatedApi;
@@ -1465,7 +1573,7 @@ exports.DeprecatedApi = DeprecatedApi;
  * MonthsApi - fetch parameter creator
  * @export
  */
-exports.MonthsApiFetchParamCreator = function (configuration) {
+const MonthsApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns a single budget month
@@ -1487,7 +1595,8 @@ exports.MonthsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/months/{month}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"month"}}`, encodeURIComponent(convertDateToFullDateStringFormat(month)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1498,12 +1607,17 @@ exports.MonthsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -1522,7 +1636,8 @@ exports.MonthsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/months`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1536,22 +1651,28 @@ exports.MonthsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.MonthsApiFetchParamCreator = MonthsApiFetchParamCreator;
 /**
  * MonthsApi - functional programming interface
  * @export
  */
-exports.MonthsApiFp = function (configuration) {
+const MonthsApiFp = function (configuration) {
     return {
         /**
          * Returns a single budget month
@@ -1562,7 +1683,7 @@ exports.MonthsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetMonth(budget_id, month, options) {
-            const localVarFetchArgs = exports.MonthsApiFetchParamCreator(configuration).getBudgetMonth(budget_id, month, options);
+            const localVarFetchArgs = (0, exports.MonthsApiFetchParamCreator)(configuration).getBudgetMonth(budget_id, month, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1587,7 +1708,7 @@ exports.MonthsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetMonths(budget_id, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.MonthsApiFetchParamCreator(configuration).getBudgetMonths(budget_id, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.MonthsApiFetchParamCreator)(configuration).getBudgetMonths(budget_id, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1605,11 +1726,12 @@ exports.MonthsApiFp = function (configuration) {
         },
     };
 };
+exports.MonthsApiFp = MonthsApiFp;
 /**
  * MonthsApi - factory interface
  * @export
  */
-exports.MonthsApiFactory = function (configuration) {
+const MonthsApiFactory = function (configuration) {
     return {
         /**
          * Returns a single budget month
@@ -1620,7 +1742,7 @@ exports.MonthsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetMonth(budget_id, month, options) {
-            return exports.MonthsApiFp(configuration).getBudgetMonth(budget_id, month, options)();
+            return (0, exports.MonthsApiFp)(configuration).getBudgetMonth(budget_id, month, options)();
         },
         /**
          * Returns all budget months
@@ -1631,10 +1753,11 @@ exports.MonthsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getBudgetMonths(budget_id, last_knowledge_of_server, options) {
-            return exports.MonthsApiFp(configuration).getBudgetMonths(budget_id, last_knowledge_of_server, options)();
+            return (0, exports.MonthsApiFp)(configuration).getBudgetMonths(budget_id, last_knowledge_of_server, options)();
         },
     };
 };
+exports.MonthsApiFactory = MonthsApiFactory;
 /**
  * MonthsApi - object-oriented interface
  * @export
@@ -1652,7 +1775,7 @@ class MonthsApi extends BaseAPI {
      * @memberof MonthsApi
      */
     getBudgetMonth(budget_id, month, options) {
-        return exports.MonthsApiFp(this.configuration).getBudgetMonth(budget_id, month, options)();
+        return (0, exports.MonthsApiFp)(this.configuration).getBudgetMonth(budget_id, month, options)();
     }
     /**
      * Returns all budget months
@@ -1664,7 +1787,7 @@ class MonthsApi extends BaseAPI {
      * @memberof MonthsApi
      */
     getBudgetMonths(budget_id, last_knowledge_of_server, options) {
-        return exports.MonthsApiFp(this.configuration).getBudgetMonths(budget_id, last_knowledge_of_server, options)();
+        return (0, exports.MonthsApiFp)(this.configuration).getBudgetMonths(budget_id, last_knowledge_of_server, options)();
     }
 }
 exports.MonthsApi = MonthsApi;
@@ -1672,7 +1795,7 @@ exports.MonthsApi = MonthsApi;
  * PayeeLocationsApi - fetch parameter creator
  * @export
  */
-exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
+const PayeeLocationsApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns a single payee location
@@ -1694,7 +1817,8 @@ exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/payee_locations/{payee_location_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_location_id"}}`, encodeURIComponent(String(payee_location_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1705,12 +1829,17 @@ exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -1728,7 +1857,8 @@ exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/payee_locations`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1739,12 +1869,17 @@ exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -1768,7 +1903,8 @@ exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/payees/{payee_id}/payee_locations`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_id"}}`, encodeURIComponent(String(payee_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1779,22 +1915,28 @@ exports.PayeeLocationsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.PayeeLocationsApiFetchParamCreator = PayeeLocationsApiFetchParamCreator;
 /**
  * PayeeLocationsApi - functional programming interface
  * @export
  */
-exports.PayeeLocationsApiFp = function (configuration) {
+const PayeeLocationsApiFp = function (configuration) {
     return {
         /**
          * Returns a single payee location
@@ -1805,7 +1947,7 @@ exports.PayeeLocationsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeLocationById(budget_id, payee_location_id, options) {
-            const localVarFetchArgs = exports.PayeeLocationsApiFetchParamCreator(configuration).getPayeeLocationById(budget_id, payee_location_id, options);
+            const localVarFetchArgs = (0, exports.PayeeLocationsApiFetchParamCreator)(configuration).getPayeeLocationById(budget_id, payee_location_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1829,7 +1971,7 @@ exports.PayeeLocationsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeLocations(budget_id, options) {
-            const localVarFetchArgs = exports.PayeeLocationsApiFetchParamCreator(configuration).getPayeeLocations(budget_id, options);
+            const localVarFetchArgs = (0, exports.PayeeLocationsApiFetchParamCreator)(configuration).getPayeeLocations(budget_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1854,7 +1996,7 @@ exports.PayeeLocationsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeLocationsByPayee(budget_id, payee_id, options) {
-            const localVarFetchArgs = exports.PayeeLocationsApiFetchParamCreator(configuration).getPayeeLocationsByPayee(budget_id, payee_id, options);
+            const localVarFetchArgs = (0, exports.PayeeLocationsApiFetchParamCreator)(configuration).getPayeeLocationsByPayee(budget_id, payee_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -1872,11 +2014,12 @@ exports.PayeeLocationsApiFp = function (configuration) {
         },
     };
 };
+exports.PayeeLocationsApiFp = PayeeLocationsApiFp;
 /**
  * PayeeLocationsApi - factory interface
  * @export
  */
-exports.PayeeLocationsApiFactory = function (configuration) {
+const PayeeLocationsApiFactory = function (configuration) {
     return {
         /**
          * Returns a single payee location
@@ -1887,7 +2030,7 @@ exports.PayeeLocationsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeLocationById(budget_id, payee_location_id, options) {
-            return exports.PayeeLocationsApiFp(configuration).getPayeeLocationById(budget_id, payee_location_id, options)();
+            return (0, exports.PayeeLocationsApiFp)(configuration).getPayeeLocationById(budget_id, payee_location_id, options)();
         },
         /**
          * Returns all payee locations
@@ -1897,7 +2040,7 @@ exports.PayeeLocationsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeLocations(budget_id, options) {
-            return exports.PayeeLocationsApiFp(configuration).getPayeeLocations(budget_id, options)();
+            return (0, exports.PayeeLocationsApiFp)(configuration).getPayeeLocations(budget_id, options)();
         },
         /**
          * Returns all payee locations for a specified payee
@@ -1908,10 +2051,11 @@ exports.PayeeLocationsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeLocationsByPayee(budget_id, payee_id, options) {
-            return exports.PayeeLocationsApiFp(configuration).getPayeeLocationsByPayee(budget_id, payee_id, options)();
+            return (0, exports.PayeeLocationsApiFp)(configuration).getPayeeLocationsByPayee(budget_id, payee_id, options)();
         },
     };
 };
+exports.PayeeLocationsApiFactory = PayeeLocationsApiFactory;
 /**
  * PayeeLocationsApi - object-oriented interface
  * @export
@@ -1929,7 +2073,7 @@ class PayeeLocationsApi extends BaseAPI {
      * @memberof PayeeLocationsApi
      */
     getPayeeLocationById(budget_id, payee_location_id, options) {
-        return exports.PayeeLocationsApiFp(this.configuration).getPayeeLocationById(budget_id, payee_location_id, options)();
+        return (0, exports.PayeeLocationsApiFp)(this.configuration).getPayeeLocationById(budget_id, payee_location_id, options)();
     }
     /**
      * Returns all payee locations
@@ -1940,7 +2084,7 @@ class PayeeLocationsApi extends BaseAPI {
      * @memberof PayeeLocationsApi
      */
     getPayeeLocations(budget_id, options) {
-        return exports.PayeeLocationsApiFp(this.configuration).getPayeeLocations(budget_id, options)();
+        return (0, exports.PayeeLocationsApiFp)(this.configuration).getPayeeLocations(budget_id, options)();
     }
     /**
      * Returns all payee locations for a specified payee
@@ -1952,7 +2096,7 @@ class PayeeLocationsApi extends BaseAPI {
      * @memberof PayeeLocationsApi
      */
     getPayeeLocationsByPayee(budget_id, payee_id, options) {
-        return exports.PayeeLocationsApiFp(this.configuration).getPayeeLocationsByPayee(budget_id, payee_id, options)();
+        return (0, exports.PayeeLocationsApiFp)(this.configuration).getPayeeLocationsByPayee(budget_id, payee_id, options)();
     }
 }
 exports.PayeeLocationsApi = PayeeLocationsApi;
@@ -1960,7 +2104,7 @@ exports.PayeeLocationsApi = PayeeLocationsApi;
  * PayeesApi - fetch parameter creator
  * @export
  */
-exports.PayeesApiFetchParamCreator = function (configuration) {
+const PayeesApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns a single payee
@@ -1982,7 +2126,8 @@ exports.PayeesApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/payees/{payee_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_id"}}`, encodeURIComponent(String(payee_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -1993,12 +2138,17 @@ exports.PayeesApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2017,7 +2167,8 @@ exports.PayeesApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/payees`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2031,22 +2182,28 @@ exports.PayeesApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.PayeesApiFetchParamCreator = PayeesApiFetchParamCreator;
 /**
  * PayeesApi - functional programming interface
  * @export
  */
-exports.PayeesApiFp = function (configuration) {
+const PayeesApiFp = function (configuration) {
     return {
         /**
          * Returns a single payee
@@ -2057,7 +2214,7 @@ exports.PayeesApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeById(budget_id, payee_id, options) {
-            const localVarFetchArgs = exports.PayeesApiFetchParamCreator(configuration).getPayeeById(budget_id, payee_id, options);
+            const localVarFetchArgs = (0, exports.PayeesApiFetchParamCreator)(configuration).getPayeeById(budget_id, payee_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2082,7 +2239,7 @@ exports.PayeesApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getPayees(budget_id, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.PayeesApiFetchParamCreator(configuration).getPayees(budget_id, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.PayeesApiFetchParamCreator)(configuration).getPayees(budget_id, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2100,11 +2257,12 @@ exports.PayeesApiFp = function (configuration) {
         },
     };
 };
+exports.PayeesApiFp = PayeesApiFp;
 /**
  * PayeesApi - factory interface
  * @export
  */
-exports.PayeesApiFactory = function (configuration) {
+const PayeesApiFactory = function (configuration) {
     return {
         /**
          * Returns a single payee
@@ -2115,7 +2273,7 @@ exports.PayeesApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getPayeeById(budget_id, payee_id, options) {
-            return exports.PayeesApiFp(configuration).getPayeeById(budget_id, payee_id, options)();
+            return (0, exports.PayeesApiFp)(configuration).getPayeeById(budget_id, payee_id, options)();
         },
         /**
          * Returns all payees
@@ -2126,10 +2284,11 @@ exports.PayeesApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getPayees(budget_id, last_knowledge_of_server, options) {
-            return exports.PayeesApiFp(configuration).getPayees(budget_id, last_knowledge_of_server, options)();
+            return (0, exports.PayeesApiFp)(configuration).getPayees(budget_id, last_knowledge_of_server, options)();
         },
     };
 };
+exports.PayeesApiFactory = PayeesApiFactory;
 /**
  * PayeesApi - object-oriented interface
  * @export
@@ -2147,7 +2306,7 @@ class PayeesApi extends BaseAPI {
      * @memberof PayeesApi
      */
     getPayeeById(budget_id, payee_id, options) {
-        return exports.PayeesApiFp(this.configuration).getPayeeById(budget_id, payee_id, options)();
+        return (0, exports.PayeesApiFp)(this.configuration).getPayeeById(budget_id, payee_id, options)();
     }
     /**
      * Returns all payees
@@ -2159,7 +2318,7 @@ class PayeesApi extends BaseAPI {
      * @memberof PayeesApi
      */
     getPayees(budget_id, last_knowledge_of_server, options) {
-        return exports.PayeesApiFp(this.configuration).getPayees(budget_id, last_knowledge_of_server, options)();
+        return (0, exports.PayeesApiFp)(this.configuration).getPayees(budget_id, last_knowledge_of_server, options)();
     }
 }
 exports.PayeesApi = PayeesApi;
@@ -2167,7 +2326,7 @@ exports.PayeesApi = PayeesApi;
  * ScheduledTransactionsApi - fetch parameter creator
  * @export
  */
-exports.ScheduledTransactionsApiFetchParamCreator = function (configuration) {
+const ScheduledTransactionsApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns a single scheduled transaction
@@ -2189,7 +2348,8 @@ exports.ScheduledTransactionsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/scheduled_transactions/{scheduled_transaction_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"scheduled_transaction_id"}}`, encodeURIComponent(String(scheduled_transaction_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2200,12 +2360,17 @@ exports.ScheduledTransactionsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2224,7 +2389,8 @@ exports.ScheduledTransactionsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/scheduled_transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2238,22 +2404,28 @@ exports.ScheduledTransactionsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.ScheduledTransactionsApiFetchParamCreator = ScheduledTransactionsApiFetchParamCreator;
 /**
  * ScheduledTransactionsApi - functional programming interface
  * @export
  */
-exports.ScheduledTransactionsApiFp = function (configuration) {
+const ScheduledTransactionsApiFp = function (configuration) {
     return {
         /**
          * Returns a single scheduled transaction
@@ -2264,7 +2436,7 @@ exports.ScheduledTransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getScheduledTransactionById(budget_id, scheduled_transaction_id, options) {
-            const localVarFetchArgs = exports.ScheduledTransactionsApiFetchParamCreator(configuration).getScheduledTransactionById(budget_id, scheduled_transaction_id, options);
+            const localVarFetchArgs = (0, exports.ScheduledTransactionsApiFetchParamCreator)(configuration).getScheduledTransactionById(budget_id, scheduled_transaction_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2289,7 +2461,7 @@ exports.ScheduledTransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getScheduledTransactions(budget_id, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.ScheduledTransactionsApiFetchParamCreator(configuration).getScheduledTransactions(budget_id, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.ScheduledTransactionsApiFetchParamCreator)(configuration).getScheduledTransactions(budget_id, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2307,11 +2479,12 @@ exports.ScheduledTransactionsApiFp = function (configuration) {
         },
     };
 };
+exports.ScheduledTransactionsApiFp = ScheduledTransactionsApiFp;
 /**
  * ScheduledTransactionsApi - factory interface
  * @export
  */
-exports.ScheduledTransactionsApiFactory = function (configuration) {
+const ScheduledTransactionsApiFactory = function (configuration) {
     return {
         /**
          * Returns a single scheduled transaction
@@ -2322,7 +2495,7 @@ exports.ScheduledTransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getScheduledTransactionById(budget_id, scheduled_transaction_id, options) {
-            return exports.ScheduledTransactionsApiFp(configuration).getScheduledTransactionById(budget_id, scheduled_transaction_id, options)();
+            return (0, exports.ScheduledTransactionsApiFp)(configuration).getScheduledTransactionById(budget_id, scheduled_transaction_id, options)();
         },
         /**
          * Returns all scheduled transactions
@@ -2333,10 +2506,11 @@ exports.ScheduledTransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getScheduledTransactions(budget_id, last_knowledge_of_server, options) {
-            return exports.ScheduledTransactionsApiFp(configuration).getScheduledTransactions(budget_id, last_knowledge_of_server, options)();
+            return (0, exports.ScheduledTransactionsApiFp)(configuration).getScheduledTransactions(budget_id, last_knowledge_of_server, options)();
         },
     };
 };
+exports.ScheduledTransactionsApiFactory = ScheduledTransactionsApiFactory;
 /**
  * ScheduledTransactionsApi - object-oriented interface
  * @export
@@ -2354,7 +2528,7 @@ class ScheduledTransactionsApi extends BaseAPI {
      * @memberof ScheduledTransactionsApi
      */
     getScheduledTransactionById(budget_id, scheduled_transaction_id, options) {
-        return exports.ScheduledTransactionsApiFp(this.configuration).getScheduledTransactionById(budget_id, scheduled_transaction_id, options)();
+        return (0, exports.ScheduledTransactionsApiFp)(this.configuration).getScheduledTransactionById(budget_id, scheduled_transaction_id, options)();
     }
     /**
      * Returns all scheduled transactions
@@ -2366,7 +2540,7 @@ class ScheduledTransactionsApi extends BaseAPI {
      * @memberof ScheduledTransactionsApi
      */
     getScheduledTransactions(budget_id, last_knowledge_of_server, options) {
-        return exports.ScheduledTransactionsApiFp(this.configuration).getScheduledTransactions(budget_id, last_knowledge_of_server, options)();
+        return (0, exports.ScheduledTransactionsApiFp)(this.configuration).getScheduledTransactions(budget_id, last_knowledge_of_server, options)();
     }
 }
 exports.ScheduledTransactionsApi = ScheduledTransactionsApi;
@@ -2374,13 +2548,13 @@ exports.ScheduledTransactionsApi = ScheduledTransactionsApi;
  * TransactionsApi - fetch parameter creator
  * @export
  */
-exports.TransactionsApiFetchParamCreator = function (configuration) {
+const TransactionsApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
          * @summary Create a single transaction or multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+         * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
@@ -2395,7 +2569,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2407,13 +2582,64 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
             localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Deletes a transaction
+         * @summary Deletes an existing transaction
+         * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+         * @param {string} transaction_id - The id of the transaction
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        deleteTransaction(budget_id, transaction_id, options = {}) {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id', 'Required parameter budget_id was null or undefined when calling deleteTransaction.');
+            }
+            // verify required parameter 'transaction_id' is not null or undefined
+            if (transaction_id === null || transaction_id === undefined) {
+                throw new RequiredError('transaction_id', 'Required parameter transaction_id was null or undefined when calling deleteTransaction.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
+                .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            const localVarRequestOptions = Object.assign({ method: 'DELETE' }, options);
+            const localVarHeaderParameter = {};
+            const localVarQueryParameter = {};
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2437,7 +2663,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2448,12 +2675,17 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2474,7 +2706,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2494,12 +2727,17 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2526,7 +2764,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/accounts/{account_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"account_id"}}`, encodeURIComponent(String(account_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2546,12 +2785,17 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2578,7 +2822,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/categories/{category_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2598,12 +2843,17 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2630,7 +2880,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/payees/{payee_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_id"}}`, encodeURIComponent(String(payee_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2650,12 +2901,17 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             if (last_knowledge_of_server !== undefined) {
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2673,7 +2929,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/transactions/import`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2684,12 +2941,17 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2698,7 +2960,7 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
          * @summary Updates an existing transaction
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {string} transaction_id - The id of the transaction
-         * @param {SaveTransactionWrapper} data - The transaction to update
+         * @param {PutTransactionWrapper} data - The transaction to update
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
@@ -2718,7 +2980,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'PUT' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2730,13 +2993,18 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
             localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2744,7 +3012,7 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
          * Updates multiple transactions, by `id` or `import_id`.
          * @summary Update multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+         * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
@@ -2759,7 +3027,8 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
             }
             const localVarPath = `/budgets/{budget_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'PATCH' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -2771,34 +3040,65 @@ exports.TransactionsApiFetchParamCreator = function (configuration) {
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
             localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.TransactionsApiFetchParamCreator = TransactionsApiFetchParamCreator;
 /**
  * TransactionsApi - functional programming interface
  * @export
  */
-exports.TransactionsApiFp = function (configuration) {
+const TransactionsApiFp = function (configuration) {
     return {
         /**
          * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
          * @summary Create a single transaction or multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+         * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         createTransaction(budget_id, data, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).createTransaction(budget_id, data, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).createTransaction(budget_id, data, options);
+            return (fetchFunction = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
+                    if (response.status >= 200 && response.status < 300) {
+                        const apiResponse = yield response.json();
+                        apiResponse.rateLimit = response.headers.get("X-Rate-Limit");
+                        return apiResponse;
+                    }
+                    else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                }));
+            };
+        },
+        /**
+         * Deletes a transaction
+         * @summary Deletes an existing transaction
+         * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+         * @param {string} transaction_id - The id of the transaction
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        deleteTransaction(budget_id, transaction_id, options) {
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).deleteTransaction(budget_id, transaction_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2823,7 +3123,7 @@ exports.TransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionById(budget_id, transaction_id, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).getTransactionById(budget_id, transaction_id, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).getTransactionById(budget_id, transaction_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2850,7 +3150,7 @@ exports.TransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactions(budget_id, since_date, type, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).getTransactions(budget_id, since_date, type, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).getTransactions(budget_id, since_date, type, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2878,7 +3178,7 @@ exports.TransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2906,7 +3206,7 @@ exports.TransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2934,7 +3234,7 @@ exports.TransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2958,7 +3258,7 @@ exports.TransactionsApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         importTransactions(budget_id, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).importTransactions(budget_id, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).importTransactions(budget_id, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -2979,12 +3279,12 @@ exports.TransactionsApiFp = function (configuration) {
          * @summary Updates an existing transaction
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {string} transaction_id - The id of the transaction
-         * @param {SaveTransactionWrapper} data - The transaction to update
+         * @param {PutTransactionWrapper} data - The transaction to update
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         updateTransaction(budget_id, transaction_id, data, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).updateTransaction(budget_id, transaction_id, data, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).updateTransaction(budget_id, transaction_id, data, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -3004,12 +3304,12 @@ exports.TransactionsApiFp = function (configuration) {
          * Updates multiple transactions, by `id` or `import_id`.
          * @summary Update multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+         * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         updateTransactions(budget_id, data, options) {
-            const localVarFetchArgs = exports.TransactionsApiFetchParamCreator(configuration).updateTransactions(budget_id, data, options);
+            const localVarFetchArgs = (0, exports.TransactionsApiFetchParamCreator)(configuration).updateTransactions(budget_id, data, options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -3027,22 +3327,34 @@ exports.TransactionsApiFp = function (configuration) {
         },
     };
 };
+exports.TransactionsApiFp = TransactionsApiFp;
 /**
  * TransactionsApi - factory interface
  * @export
  */
-exports.TransactionsApiFactory = function (configuration) {
+const TransactionsApiFactory = function (configuration) {
     return {
         /**
          * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
          * @summary Create a single transaction or multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+         * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         createTransaction(budget_id, data, options) {
-            return exports.TransactionsApiFp(configuration).createTransaction(budget_id, data, options)();
+            return (0, exports.TransactionsApiFp)(configuration).createTransaction(budget_id, data, options)();
+        },
+        /**
+         * Deletes a transaction
+         * @summary Deletes an existing transaction
+         * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+         * @param {string} transaction_id - The id of the transaction
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        deleteTransaction(budget_id, transaction_id, options) {
+            return (0, exports.TransactionsApiFp)(configuration).deleteTransaction(budget_id, transaction_id, options)();
         },
         /**
          * Returns a single transaction
@@ -3053,7 +3365,7 @@ exports.TransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionById(budget_id, transaction_id, options) {
-            return exports.TransactionsApiFp(configuration).getTransactionById(budget_id, transaction_id, options)();
+            return (0, exports.TransactionsApiFp)(configuration).getTransactionById(budget_id, transaction_id, options)();
         },
         /**
          * Returns budget transactions
@@ -3066,7 +3378,7 @@ exports.TransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactions(budget_id, since_date, type, last_knowledge_of_server, options) {
-            return exports.TransactionsApiFp(configuration).getTransactions(budget_id, since_date, type, last_knowledge_of_server, options)();
+            return (0, exports.TransactionsApiFp)(configuration).getTransactions(budget_id, since_date, type, last_knowledge_of_server, options)();
         },
         /**
          * Returns all transactions for a specified account
@@ -3080,7 +3392,7 @@ exports.TransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options) {
-            return exports.TransactionsApiFp(configuration).getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options)();
+            return (0, exports.TransactionsApiFp)(configuration).getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options)();
         },
         /**
          * Returns all transactions for a specified category
@@ -3094,7 +3406,7 @@ exports.TransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options) {
-            return exports.TransactionsApiFp(configuration).getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options)();
+            return (0, exports.TransactionsApiFp)(configuration).getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options)();
         },
         /**
          * Returns all transactions for a specified payee
@@ -3108,7 +3420,7 @@ exports.TransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options) {
-            return exports.TransactionsApiFp(configuration).getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options)();
+            return (0, exports.TransactionsApiFp)(configuration).getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options)();
         },
         /**
          * Imports available transactions on all linked accounts for the given budget.  Linked accounts allow transactions to be imported directly from a specified financial institution and this endpoint initiates that import.  Sending a request to this endpoint is the equivalent of clicking \"Import\" on each account in the web application or tapping the \"New Transactions\" banner in the mobile applications.  The response for this endpoint contains the transaction ids that have been imported.
@@ -3118,33 +3430,34 @@ exports.TransactionsApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         importTransactions(budget_id, options) {
-            return exports.TransactionsApiFp(configuration).importTransactions(budget_id, options)();
+            return (0, exports.TransactionsApiFp)(configuration).importTransactions(budget_id, options)();
         },
         /**
          * Updates a single transaction
          * @summary Updates an existing transaction
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {string} transaction_id - The id of the transaction
-         * @param {SaveTransactionWrapper} data - The transaction to update
+         * @param {PutTransactionWrapper} data - The transaction to update
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         updateTransaction(budget_id, transaction_id, data, options) {
-            return exports.TransactionsApiFp(configuration).updateTransaction(budget_id, transaction_id, data, options)();
+            return (0, exports.TransactionsApiFp)(configuration).updateTransaction(budget_id, transaction_id, data, options)();
         },
         /**
          * Updates multiple transactions, by `id` or `import_id`.
          * @summary Update multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+         * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
         updateTransactions(budget_id, data, options) {
-            return exports.TransactionsApiFp(configuration).updateTransactions(budget_id, data, options)();
+            return (0, exports.TransactionsApiFp)(configuration).updateTransactions(budget_id, data, options)();
         },
     };
 };
+exports.TransactionsApiFactory = TransactionsApiFactory;
 /**
  * TransactionsApi - object-oriented interface
  * @export
@@ -3156,13 +3469,25 @@ class TransactionsApi extends BaseAPI {
      * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+     * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
     createTransaction(budget_id, data, options) {
-        return exports.TransactionsApiFp(this.configuration).createTransaction(budget_id, data, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).createTransaction(budget_id, data, options)();
+    }
+    /**
+     * Deletes a transaction
+     * @summary Deletes an existing transaction
+     * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+     * @param {string} transaction_id - The id of the transaction
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    deleteTransaction(budget_id, transaction_id, options) {
+        return (0, exports.TransactionsApiFp)(this.configuration).deleteTransaction(budget_id, transaction_id, options)();
     }
     /**
      * Returns a single transaction
@@ -3174,7 +3499,7 @@ class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     getTransactionById(budget_id, transaction_id, options) {
-        return exports.TransactionsApiFp(this.configuration).getTransactionById(budget_id, transaction_id, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).getTransactionById(budget_id, transaction_id, options)();
     }
     /**
      * Returns budget transactions
@@ -3188,7 +3513,7 @@ class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     getTransactions(budget_id, since_date, type, last_knowledge_of_server, options) {
-        return exports.TransactionsApiFp(this.configuration).getTransactions(budget_id, since_date, type, last_knowledge_of_server, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).getTransactions(budget_id, since_date, type, last_knowledge_of_server, options)();
     }
     /**
      * Returns all transactions for a specified account
@@ -3203,7 +3528,7 @@ class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options) {
-        return exports.TransactionsApiFp(this.configuration).getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).getTransactionsByAccount(budget_id, account_id, since_date, type, last_knowledge_of_server, options)();
     }
     /**
      * Returns all transactions for a specified category
@@ -3218,7 +3543,7 @@ class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options) {
-        return exports.TransactionsApiFp(this.configuration).getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).getTransactionsByCategory(budget_id, category_id, since_date, type, last_knowledge_of_server, options)();
     }
     /**
      * Returns all transactions for a specified payee
@@ -3233,7 +3558,7 @@ class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options) {
-        return exports.TransactionsApiFp(this.configuration).getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).getTransactionsByPayee(budget_id, payee_id, since_date, type, last_knowledge_of_server, options)();
     }
     /**
      * Imports available transactions on all linked accounts for the given budget.  Linked accounts allow transactions to be imported directly from a specified financial institution and this endpoint initiates that import.  Sending a request to this endpoint is the equivalent of clicking \"Import\" on each account in the web application or tapping the \"New Transactions\" banner in the mobile applications.  The response for this endpoint contains the transaction ids that have been imported.
@@ -3244,32 +3569,32 @@ class TransactionsApi extends BaseAPI {
      * @memberof TransactionsApi
      */
     importTransactions(budget_id, options) {
-        return exports.TransactionsApiFp(this.configuration).importTransactions(budget_id, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).importTransactions(budget_id, options)();
     }
     /**
      * Updates a single transaction
      * @summary Updates an existing transaction
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {string} transaction_id - The id of the transaction
-     * @param {SaveTransactionWrapper} data - The transaction to update
+     * @param {PutTransactionWrapper} data - The transaction to update
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
     updateTransaction(budget_id, transaction_id, data, options) {
-        return exports.TransactionsApiFp(this.configuration).updateTransaction(budget_id, transaction_id, data, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).updateTransaction(budget_id, transaction_id, data, options)();
     }
     /**
      * Updates multiple transactions, by `id` or `import_id`.
      * @summary Update multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+     * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
     updateTransactions(budget_id, data, options) {
-        return exports.TransactionsApiFp(this.configuration).updateTransactions(budget_id, data, options)();
+        return (0, exports.TransactionsApiFp)(this.configuration).updateTransactions(budget_id, data, options)();
     }
 }
 exports.TransactionsApi = TransactionsApi;
@@ -3277,7 +3602,7 @@ exports.TransactionsApi = TransactionsApi;
  * UserApi - fetch parameter creator
  * @export
  */
-exports.UserApiFetchParamCreator = function (configuration) {
+const UserApiFetchParamCreator = function (configuration) {
     return {
         /**
          * Returns authenticated user information
@@ -3287,7 +3612,8 @@ exports.UserApiFetchParamCreator = function (configuration) {
          */
         getUser(options = {}) {
             const localVarPath = `/user`;
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
@@ -3298,22 +3624,28 @@ exports.UserApiFetchParamCreator = function (configuration) {
                 const localVarApiKeyValue = configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
     };
 };
+exports.UserApiFetchParamCreator = UserApiFetchParamCreator;
 /**
  * UserApi - functional programming interface
  * @export
  */
-exports.UserApiFp = function (configuration) {
+const UserApiFp = function (configuration) {
     return {
         /**
          * Returns authenticated user information
@@ -3322,7 +3654,7 @@ exports.UserApiFp = function (configuration) {
          * @throws {RequiredError}
          */
         getUser(options) {
-            const localVarFetchArgs = exports.UserApiFetchParamCreator(configuration).getUser(options);
+            const localVarFetchArgs = (0, exports.UserApiFetchParamCreator)(configuration).getUser(options);
             return (fetchFunction = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => __awaiter(this, void 0, void 0, function* () {
                     if (response.status >= 200 && response.status < 300) {
@@ -3340,11 +3672,12 @@ exports.UserApiFp = function (configuration) {
         },
     };
 };
+exports.UserApiFp = UserApiFp;
 /**
  * UserApi - factory interface
  * @export
  */
-exports.UserApiFactory = function (configuration) {
+const UserApiFactory = function (configuration) {
     return {
         /**
          * Returns authenticated user information
@@ -3353,10 +3686,11 @@ exports.UserApiFactory = function (configuration) {
          * @throws {RequiredError}
          */
         getUser(options) {
-            return exports.UserApiFp(configuration).getUser(options)();
+            return (0, exports.UserApiFp)(configuration).getUser(options)();
         },
     };
 };
+exports.UserApiFactory = UserApiFactory;
 /**
  * UserApi - object-oriented interface
  * @export
@@ -3372,7 +3706,7 @@ class UserApi extends BaseAPI {
      * @memberof UserApi
      */
     getUser(options) {
-        return exports.UserApiFp(this.configuration).getUser(options)();
+        return (0, exports.UserApiFp)(this.configuration).getUser(options)();
     }
 }
 exports.UserApi = UserApi;

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,7 +19,7 @@ var __createBinding = (this && this.__createBinding) || (Object.create ? (functi
     o[k2] = m[k];
 }));
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
-    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.api = exports.utils = exports.API = void 0;

--- a/dist/transactionsApi.d.ts
+++ b/dist/transactionsApi.d.ts
@@ -22,7 +22,7 @@ export declare class TransactionsApi extends CodeGen.TransactionsApi {
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    createTransactions(budget_id: string, data: CodeGen.SaveTransactionsWrapper, options?: any): Promise<CodeGen.SaveTransactionsResponse & {
+    createTransactions(budget_id: string, data: CodeGen.PostTransactionsWrapper, options?: any): Promise<CodeGen.SaveTransactionsResponse & {
         rateLimit: string | null;
     }>;
     /**

--- a/examples/budget-list/index.js
+++ b/examples/budget-list/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 (async function () {

--- a/examples/budget-list/index.ts
+++ b/examples/budget-list/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/budget-month/index.js
+++ b/examples/budget-month/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 ynabAPI.months

--- a/examples/budget-month/index.ts
+++ b/examples/budget-month/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/bulk-transaction-create/index.js
+++ b/examples/bulk-transaction-create/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 const bulkTransactions = {

--- a/examples/bulk-transaction-create/index.ts
+++ b/examples/bulk-transaction-create/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/category-balance/index.js
+++ b/examples/category-balance/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 ynabAPI.categories

--- a/examples/category-balance/index.ts
+++ b/examples/category-balance/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/create-account/index.js
+++ b/examples/create-account/index.js
@@ -5,7 +5,7 @@ const budgetId = "378f111e-4b27-4ee5-a9fd-0ba03c1de0f0";
 (async function () {
     const account = {
         name: "New Account",
-        type: ynab.SaveAccount.TypeEnum.Checking,
+        type: ynab.AccountType.Checking,
         balance: 103352,
     };
     try {

--- a/examples/create-account/index.js
+++ b/examples/create-account/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 const budgetId = "378f111e-4b27-4ee5-a9fd-0ba03c1de0f0";

--- a/examples/create-account/index.ts
+++ b/examples/create-account/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/create-account/index.ts
+++ b/examples/create-account/index.ts
@@ -8,7 +8,7 @@ const budgetId = "378f111e-4b27-4ee5-a9fd-0ba03c1de0f0";
 (async function () {
   const account: ynab.SaveAccount = {
     name: "New Account",
-    type: ynab.SaveAccount.TypeEnum.Checking,
+    type: ynab.AccountType.Checking,
     balance: 103352,
   };
 

--- a/examples/create-multiple-transactions/index.js
+++ b/examples/create-multiple-transactions/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 const budgetId = "378f111e-4b27-4ee5-a9fd-0ba03c1de0f0";

--- a/examples/create-multiple-transactions/index.ts
+++ b/examples/create-multiple-transactions/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/create-transaction/index.js
+++ b/examples/create-transaction/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 const budgetId = "378f111e-4b27-4ee5-a9fd-0ba03c1de0f0";

--- a/examples/create-transaction/index.ts
+++ b/examples/create-transaction/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/delete-transaction/index.js
+++ b/examples/delete-transaction/index.js
@@ -1,0 +1,28 @@
+import * as ynab from "../../src/index";
+const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
+const ynabAPI = new ynab.API(accessToken);
+const budgetId = "default";
+const transactionId = "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da";
+(async function () {
+    // Fetch transaction before deleting it
+    await ynabAPI.transactions.getTransactionById(budgetId, transactionId);
+    // Delete the transaction
+    await ynabAPI.transactions.deleteTransaction(budgetId, transactionId);
+    // Try to fetch the transaction again and see that it was deleted
+    try {
+        await ynabAPI.transactions.getTransactionById(budgetId, transactionId);
+    }
+    catch (error) {
+        console.log("As expected, the transaction was not found because it was deleted.");
+        /* Error response object will look like this:
+    
+          {
+            id: '404.2',
+            name: 'resource_not_found',
+            detail: 'Resource not found'
+          }
+    
+        */
+        console.log(`ERROR: id=${error.id}; name=${error.name}; detail: ${error.detail}`);
+    }
+})();

--- a/examples/delete-transaction/index.ts
+++ b/examples/delete-transaction/index.ts
@@ -1,0 +1,38 @@
+import * as ynab from "../../src/index";
+
+const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
+const ynabAPI = new ynab.API(accessToken);
+
+const budgetId = "default";
+const transactionId = "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da";
+
+(async function () {
+  // Fetch transaction before deleting it
+  await ynabAPI.transactions.getTransactionById(budgetId, transactionId);
+
+  // Delete the transaction
+  await ynabAPI.transactions.deleteTransaction(budgetId, transactionId);
+
+  // Try to fetch the transaction again and see that it was deleted
+  try {
+    await ynabAPI.transactions.getTransactionById(budgetId, transactionId);
+  } catch (error) {
+    console.log(
+      "As expected, the transaction was not found because it was deleted."
+    );
+
+    /* Error response object will look like this:
+
+      {
+        id: '404.2',
+        name: 'resource_not_found',
+        detail: 'Resource not found'
+      }
+
+    */
+
+    console.log(
+      `ERROR: id=${error.id}; name=${error.name}; detail: ${error.detail}`
+    );
+  }
+})();

--- a/examples/delta-request/index.js
+++ b/examples/delta-request/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 (async function () {

--- a/examples/delta-request/index.ts
+++ b/examples/delta-request/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "module": "commonjs",
+    "module": "ESNext",
     "noImplicitAny": true,
     "noImplicitUseStrict": true
   },

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -5,5 +5,6 @@
     "noImplicitAny": true,
     "noImplicitUseStrict": true
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts"],
+  "references": [{ "path": "../src" }]
 }

--- a/examples/update-category-budgeted/index.js
+++ b/examples/update-category-budgeted/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 const budgetId = "f968197b-2863-473a-8974-c2406dbe7f0d";

--- a/examples/update-category-budgeted/index.ts
+++ b/examples/update-category-budgeted/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/examples/update-multiple-transactions/index.js
+++ b/examples/update-multiple-transactions/index.js
@@ -1,0 +1,16 @@
+import * as ynab from "../../src/index";
+const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
+const ynabAPI = new ynab.API(accessToken);
+await ynabAPI.transactions.updateTransactions("default", {
+    transactions: [
+        { id: "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da", memo: "Updated memo" },
+        {
+            id: "829278fb-9820-4e47-8f6c-2f9cae18ce22",
+            flag_color: ynab.SaveTransaction.FlagColorEnum.Green,
+        },
+        {
+            id: "cfbacd22-1e71-4dab-9733-ad2da64c824d",
+            category_id: "50847dd8-5d8d-41cc-af8b-a3b5fd46150c",
+        },
+    ],
+});

--- a/examples/update-multiple-transactions/index.ts
+++ b/examples/update-multiple-transactions/index.ts
@@ -1,0 +1,20 @@
+import * as ynab from "../../src/index";
+
+const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
+const ynabAPI = new ynab.API(accessToken);
+
+(async function () {
+  await ynabAPI.transactions.updateTransactions("default", {
+    transactions: [
+      { id: "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da", memo: "Updated memo" },
+      {
+        id: "829278fb-9820-4e47-8f6c-2f9cae18ce22",
+        flag_color: ynab.SaveTransaction.FlagColorEnum.Green,
+      },
+      {
+        id: "cfbacd22-1e71-4dab-9733-ad2da64c824d",
+        category_id: "50847dd8-5d8d-41cc-af8b-a3b5fd46150c",
+      },
+    ],
+  });
+})();

--- a/examples/update-transaction/index.js
+++ b/examples/update-transaction/index.js
@@ -8,6 +8,7 @@ const transactionId = "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da";
         const transaction = (await ynabAPI.transactions.getTransactionById(budgetId, transactionId)).data.transaction;
         transaction.memo = "Updated memo";
         transaction.flag_color = ynab.SaveTransaction.FlagColorEnum.Blue;
+        transaction.id;
         await ynabAPI.transactions.updateTransaction(budgetId, transactionId, {
             transaction
         });

--- a/examples/update-transaction/index.js
+++ b/examples/update-transaction/index.js
@@ -1,5 +1,4 @@
-Object.defineProperty(exports, "__esModule", { value: true });
-const ynab = require("../../dist/index.js");
+import * as ynab from "../../src/index";
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);
 const budgetId = "f968197b-2863-473a-8974-c2406dbe7f0d";

--- a/examples/update-transaction/index.ts
+++ b/examples/update-transaction/index.ts
@@ -15,6 +15,7 @@ const transactionId = "8fdf39f9-8f62-4efe-8dd2-64cb167ac6da";
 
     transaction.memo = "Updated memo";
     transaction.flag_color = ynab.SaveTransaction.FlagColorEnum.Blue;
+    transaction.id
 
     await ynabAPI.transactions.updateTransaction(budgetId, transactionId, {
       transaction

--- a/examples/update-transaction/index.ts
+++ b/examples/update-transaction/index.ts
@@ -1,4 +1,4 @@
-import * as ynab from "../../dist/index.js";
+import * as ynab from "../../src/index";
 
 const accessToken = "ccbb2db8-7c1b-not-real-b755-784876927790";
 const ynabAPI = new ynab.API(accessToken);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "swagger-model-validator": "^3.0.19",
         "ts-loader": "^8.0.2",
         "ts-node": "^8.10.2",
-        "typescript": "^3.9.7",
+        "typescript": "4.5.5",
         "url": "^0.11.0",
         "webpack": "^5.74.0",
         "webpack-cli": "^5.0.1"
@@ -3109,9 +3109,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5860,9 +5860,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "swagger-model-validator": "^3.0.19",
     "ts-loader": "^8.0.2",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.7",
+    "typescript": "4.5.5",
     "url": "^0.11.0",
     "webpack": "^5.74.0",
     "webpack-cli": "^5.0.1"

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,7 @@ if (!globalThis.fetch) {
 import * as url from "url";
 import { Configuration } from "./configuration";
 
-const USER_AGENT = "api_client/js/1.32.0";
+const USER_AGENT = "api_client/js/1.42.0";
 
 function convertDateToFullDateStringFormat(date: Date | string): string {
   // Convert to RFC 3339 "full-date" format, like "2017-11-27"
@@ -995,6 +995,34 @@ export interface MonthSummary {
 /**
  * 
  * @export
+ * @interface PatchMonthCategoryWrapper
+ */
+export interface PatchMonthCategoryWrapper {
+    /**
+     * 
+     * @type {SaveMonthCategory}
+     * @memberof PatchMonthCategoryWrapper
+     */
+    category: SaveMonthCategory;
+}
+
+/**
+ * 
+ * @export
+ * @interface PatchTransactionsWrapper
+ */
+export interface PatchTransactionsWrapper {
+    /**
+     * 
+     * @type {Array<SaveTransactionWithId>}
+     * @memberof PatchTransactionsWrapper
+     */
+    transactions: Array<SaveTransactionWithId>;
+}
+
+/**
+ * 
+ * @export
  * @interface Payee
  */
 export interface Payee {
@@ -1183,6 +1211,54 @@ export interface PayeesResponseData {
 /**
  * 
  * @export
+ * @interface PostAccountWrapper
+ */
+export interface PostAccountWrapper {
+    /**
+     * 
+     * @type {SaveAccount}
+     * @memberof PostAccountWrapper
+     */
+    account: SaveAccount;
+}
+
+/**
+ * 
+ * @export
+ * @interface PostTransactionsWrapper
+ */
+export interface PostTransactionsWrapper {
+    /**
+     * 
+     * @type {SaveTransaction}
+     * @memberof PostTransactionsWrapper
+     */
+    transaction?: SaveTransaction | null;
+    /**
+     * 
+     * @type {Array<SaveTransaction>}
+     * @memberof PostTransactionsWrapper
+     */
+    transactions?: Array<SaveTransaction> | null;
+}
+
+/**
+ * 
+ * @export
+ * @interface PutTransactionWrapper
+ */
+export interface PutTransactionWrapper {
+    /**
+     * 
+     * @type {SaveTransaction}
+     * @memberof PutTransactionWrapper
+     */
+    transaction: SaveTransaction;
+}
+
+/**
+ * 
+ * @export
  * @interface SaveAccount
  */
 export interface SaveAccount {
@@ -1204,20 +1280,6 @@ export interface SaveAccount {
      * @memberof SaveAccount
      */
     balance: number;
-}
-
-/**
- * 
- * @export
- * @interface SaveAccountWrapper
- */
-export interface SaveAccountWrapper {
-    /**
-     * 
-     * @type {SaveAccount}
-     * @memberof SaveAccountWrapper
-     */
-    account: SaveAccount;
 }
 
 /**
@@ -1271,20 +1333,6 @@ export interface SaveMonthCategory {
 /**
  * 
  * @export
- * @interface SaveMonthCategoryWrapper
- */
-export interface SaveMonthCategoryWrapper {
-    /**
-     * 
-     * @type {SaveMonthCategory}
-     * @memberof SaveMonthCategoryWrapper
-     */
-    category: SaveMonthCategory;
-}
-
-/**
- * 
- * @export
  * @interface SaveSubTransaction
  */
 export interface SaveSubTransaction {
@@ -1323,88 +1371,88 @@ export interface SaveSubTransaction {
 /**
  * 
  * @export
- * @interface SaveTransaction
+ * @interface SaveTransactionWithOptionalFields
  */
-export interface SaveTransaction {
+export interface SaveTransactionWithOptionalFields {
     /**
      * 
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    account_id: string;
+    account_id?: string | null;
     /**
      * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    date: string;
+    date?: string | null;
     /**
      * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
      * @type {number}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    amount: number;
+    amount?: number | null;
     /**
      * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     payee_id?: string | null;
     /**
      * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     payee_name?: string | null;
     /**
      * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     category_id?: string | null;
     /**
      * 
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     memo?: string | null;
     /**
      * The cleared status of the transaction
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    cleared?: SaveTransaction.ClearedEnum | null;
+    cleared?: SaveTransactionWithOptionalFields.ClearedEnum | null;
     /**
      * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
      * @type {boolean}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     approved?: boolean | null;
     /**
      * The transaction flag
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
-    flag_color?: SaveTransaction.FlagColorEnum | null;
+    flag_color?: SaveTransactionWithOptionalFields.FlagColorEnum | null;
     /**
      * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
      * @type {string}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     import_id?: string | null;
     /**
      * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
      * @type {Array<SaveSubTransaction>}
-     * @memberof SaveTransaction
+     * @memberof SaveTransactionWithOptionalFields
      */
     subtransactions?: Array<SaveSubTransaction> | null;
 }
 
 /**
  * @export
- * @namespace SaveTransaction
+ * @namespace SaveTransactionWithOptionalFields
  */
-export namespace SaveTransaction {
+export namespace SaveTransactionWithOptionalFields {
     /**
      * @export
      * @enum {string}
@@ -1426,20 +1474,6 @@ export namespace SaveTransaction {
         Blue = <any> 'blue',
         Purple = <any> 'purple'
     }
-}
-
-/**
- * 
- * @export
- * @interface SaveTransactionWrapper
- */
-export interface SaveTransactionWrapper {
-    /**
-     * 
-     * @type {SaveTransaction}
-     * @memberof SaveTransactionWrapper
-     */
-    transaction: SaveTransaction;
 }
 
 /**
@@ -1492,26 +1526,6 @@ export interface SaveTransactionsResponseData {
      * @memberof SaveTransactionsResponseData
      */
     server_knowledge: number;
-}
-
-/**
- * 
- * @export
- * @interface SaveTransactionsWrapper
- */
-export interface SaveTransactionsWrapper {
-    /**
-     * 
-     * @type {SaveTransaction}
-     * @memberof SaveTransactionsWrapper
-     */
-    transaction?: SaveTransaction | null;
-    /**
-     * 
-     * @type {Array<SaveTransaction>}
-     * @memberof SaveTransactionsWrapper
-     */
-    transactions?: Array<SaveTransaction> | null;
 }
 
 /**
@@ -1937,11 +1951,23 @@ export interface TransactionSummary {
      */
     matched_transaction_id?: string | null;
     /**
-     * If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     * If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
      * @type {string}
      * @memberof TransactionSummary
      */
     import_id?: string | null;
+    /**
+     * If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules
+     * @type {string}
+     * @memberof TransactionSummary
+     */
+    import_payee_name?: string | null;
+    /**
+     * If the transaction was imported, the original payee name as it appeared on the statement
+     * @type {string}
+     * @memberof TransactionSummary
+     */
+    import_payee_name_original?: string | null;
     /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
@@ -2038,20 +2064,6 @@ export interface TransactionsResponseData {
      * @memberof TransactionsResponseData
      */
     server_knowledge: number;
-}
-
-/**
- * 
- * @export
- * @interface UpdateTransactionsWrapper
- */
-export interface UpdateTransactionsWrapper {
-    /**
-     * 
-     * @type {Array<UpdateTransaction>}
-     * @memberof UpdateTransactionsWrapper
-     */
-    transactions: Array<UpdateTransaction>;
 }
 
 /**
@@ -2329,11 +2341,23 @@ export interface HybridTransaction {
      */
     matched_transaction_id?: string | null;
     /**
-     * If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     * If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
      * @type {string}
      * @memberof HybridTransaction
      */
     import_id?: string | null;
+    /**
+     * If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules
+     * @type {string}
+     * @memberof HybridTransaction
+     */
+    import_payee_name?: string | null;
+    /**
+     * If the transaction was imported, the original payee name as it appeared on the statement
+     * @type {string}
+     * @memberof HybridTransaction
+     */
+    import_payee_name_original?: string | null;
     /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
@@ -2468,6 +2492,228 @@ export interface MonthDetail {
      * @memberof MonthDetail
      */
     categories: Array<Category>;
+}
+
+/**
+ * 
+ * @export
+ * @interface SaveTransaction
+ */
+export interface SaveTransaction {
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    account_id?: string | null;
+    /**
+     * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    date?: string | null;
+    /**
+     * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
+     * @type {number}
+     * @memberof SaveTransaction
+     */
+    amount?: number | null;
+    /**
+     * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    payee_id?: string | null;
+    /**
+     * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    payee_name?: string | null;
+    /**
+     * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    category_id?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    memo?: string | null;
+    /**
+     * The cleared status of the transaction
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    cleared?: SaveTransaction.ClearedEnum | null;
+    /**
+     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
+     * @type {boolean}
+     * @memberof SaveTransaction
+     */
+    approved?: boolean | null;
+    /**
+     * The transaction flag
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    flag_color?: SaveTransaction.FlagColorEnum | null;
+    /**
+     * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
+     * @type {string}
+     * @memberof SaveTransaction
+     */
+    import_id?: string | null;
+    /**
+     * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
+     * @type {Array<SaveSubTransaction>}
+     * @memberof SaveTransaction
+     */
+    subtransactions?: Array<SaveSubTransaction> | null;
+}
+
+/**
+ * @export
+ * @namespace SaveTransaction
+ */
+export namespace SaveTransaction {
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum ClearedEnum {
+        Cleared = <any> 'cleared',
+        Uncleared = <any> 'uncleared',
+        Reconciled = <any> 'reconciled'
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum FlagColorEnum {
+        Red = <any> 'red',
+        Orange = <any> 'orange',
+        Yellow = <any> 'yellow',
+        Green = <any> 'green',
+        Blue = <any> 'blue',
+        Purple = <any> 'purple'
+    }
+}
+
+/**
+ * 
+ * @export
+ * @interface SaveTransactionWithId
+ */
+export interface SaveTransactionWithId {
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    account_id?: string | null;
+    /**
+     * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    date?: string | null;
+    /**
+     * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
+     * @type {number}
+     * @memberof SaveTransactionWithId
+     */
+    amount?: number | null;
+    /**
+     * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    payee_id?: string | null;
+    /**
+     * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    payee_name?: string | null;
+    /**
+     * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    category_id?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    memo?: string | null;
+    /**
+     * The cleared status of the transaction
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    cleared?: SaveTransactionWithId.ClearedEnum | null;
+    /**
+     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
+     * @type {boolean}
+     * @memberof SaveTransactionWithId
+     */
+    approved?: boolean | null;
+    /**
+     * The transaction flag
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    flag_color?: SaveTransactionWithId.FlagColorEnum | null;
+    /**
+     * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    import_id?: string | null;
+    /**
+     * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
+     * @type {Array<SaveSubTransaction>}
+     * @memberof SaveTransactionWithId
+     */
+    subtransactions?: Array<SaveSubTransaction> | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SaveTransactionWithId
+     */
+    id?: string | null;
+}
+
+/**
+ * @export
+ * @namespace SaveTransactionWithId
+ */
+export namespace SaveTransactionWithId {
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum ClearedEnum {
+        Cleared = <any> 'cleared',
+        Uncleared = <any> 'uncleared',
+        Reconciled = <any> 'reconciled'
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum FlagColorEnum {
+        Red = <any> 'red',
+        Orange = <any> 'orange',
+        Yellow = <any> 'yellow',
+        Green = <any> 'green',
+        Blue = <any> 'blue',
+        Purple = <any> 'purple'
+    }
 }
 
 /**
@@ -2697,11 +2943,23 @@ export interface TransactionDetail {
      */
     matched_transaction_id?: string | null;
     /**
-     * If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     * If the transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
      * @type {string}
      * @memberof TransactionDetail
      */
     import_id?: string | null;
+    /**
+     * If the transaction was imported, the payee name that was used when importing and before applying any payee rename rules
+     * @type {string}
+     * @memberof TransactionDetail
+     */
+    import_payee_name?: string | null;
+    /**
+     * If the transaction was imported, the original payee name as it appeared on the statement
+     * @type {string}
+     * @memberof TransactionDetail
+     */
+    import_payee_name_original?: string | null;
     /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
@@ -2762,120 +3020,6 @@ export namespace TransactionDetail {
     }
 }
 
-/**
- * 
- * @export
- * @interface UpdateTransaction
- */
-export interface UpdateTransaction {
-    /**
-     * 
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    account_id: string;
-    /**
-     * The transaction date in ISO format (e.g. 2016-12-01).  Future dates (scheduled transactions) are not permitted.  Split transaction dates cannot be changed and if a different date is supplied it will be ignored.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    date: string;
-    /**
-     * The transaction amount in milliunits format.  Split transaction amounts cannot be changed and if a different amount is supplied it will be ignored.
-     * @type {number}
-     * @memberof UpdateTransaction
-     */
-    amount: number;
-    /**
-     * The payee for the transaction.  To create a transfer between two accounts, use the account transfer payee pointing to the target account.  Account transfer payees are specified as `tranfer_payee_id` on the account resource.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    payee_id?: string | null;
-    /**
-     * The payee name.  If a `payee_name` value is provided and `payee_id` has a null value, the `payee_name` value will be used to resolve the payee by either (1) a matching payee rename rule (only if `import_id` is also specified) or (2) a payee with the same name or (3) creation of a new payee.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    payee_name?: string | null;
-    /**
-     * The category for the transaction.  To configure a split transaction, you can specify null for `category_id` and provide a `subtransactions` array as part of the transaction object.  If an existing transaction is a split, the `category_id` cannot be changed.  Credit Card Payment categories are not permitted and will be ignored if supplied.
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    category_id?: string | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    memo?: string | null;
-    /**
-     * The cleared status of the transaction
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    cleared?: UpdateTransaction.ClearedEnum | null;
-    /**
-     * Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default.
-     * @type {boolean}
-     * @memberof UpdateTransaction
-     */
-    approved?: boolean | null;
-    /**
-     * The transaction flag
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    flag_color?: UpdateTransaction.FlagColorEnum | null;
-    /**
-     * If specified, the new transaction will be assigned this `import_id` and considered \"imported\".  We will also attempt to match this imported transaction to an existing \"user-entered\" transation on the same account, with the same amount, and with a date +/-10 days from the imported transaction date.<br><br>Transactions imported through File Based Import or Direct Import (not through the API) are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.<br><br>If import_id is omitted or specified as null, the transaction will be treated as a \"user-entered\" transaction. As such, it will be eligible to be matched against transactions later being imported (via DI, FBI, or API).
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    import_id?: string | null;
-    /**
-     * An array of subtransactions to configure a transaction as a split.  Updating `subtransactions` on an existing split transaction is not supported.
-     * @type {Array<SaveSubTransaction>}
-     * @memberof UpdateTransaction
-     */
-    subtransactions?: Array<SaveSubTransaction> | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof UpdateTransaction
-     */
-    id: string;
-}
-
-/**
- * @export
- * @namespace UpdateTransaction
- */
-export namespace UpdateTransaction {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum ClearedEnum {
-        Cleared = <any> 'cleared',
-        Uncleared = <any> 'uncleared',
-        Reconciled = <any> 'reconciled'
-    }
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum FlagColorEnum {
-        Red = <any> 'red',
-        Orange = <any> 'orange',
-        Yellow = <any> 'yellow',
-        Green = <any> 'green',
-        Blue = <any> 'blue',
-        Purple = <any> 'purple'
-    }
-}
-
 
 /**
  * AccountsApi - fetch parameter creator
@@ -2887,11 +3031,11 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
          * Creates a new account
          * @summary Create a new account
          * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-         * @param {SaveAccountWrapper} data - The account to create.
+         * @param {PostAccountWrapper} data - The account to create.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        createAccount(budget_id: string, data: SaveAccountWrapper, options: any = {}): FetchArgs {
+        createAccount(budget_id: string, data: PostAccountWrapper, options: any = {}): FetchArgs {
             // verify required parameter 'budget_id' is not null or undefined
             if (budget_id === null || budget_id === undefined) {
                 throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling createAccount.');
@@ -2902,7 +3046,8 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
             }
             const localVarPath = `/budgets/{budget_id}/accounts`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -2918,14 +3063,19 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2949,7 +3099,8 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
             const localVarPath = `/budgets/{budget_id}/accounts/{account_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"account_id"}}`, encodeURIComponent(String(account_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -2963,13 +3114,18 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -2988,7 +3144,8 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
             }
             const localVarPath = `/budgets/{budget_id}/accounts`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3006,13 +3163,18 @@ export const AccountsApiFetchParamCreator = function (configuration: Configurati
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3029,11 +3191,11 @@ export const AccountsApiFp = function(configuration: Configuration) {
          * Creates a new account
          * @summary Create a new account
          * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-         * @param {SaveAccountWrapper} data - The account to create.
+         * @param {PostAccountWrapper} data - The account to create.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        createAccount(budget_id: string, data: SaveAccountWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<AccountResponse & { rateLimit: string | null }> {
+        createAccount(budget_id: string, data: PostAccountWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<AccountResponse & { rateLimit: string | null }> {
             const localVarFetchArgs = AccountsApiFetchParamCreator(configuration).createAccount(budget_id, data, options);
             return (fetchFunction: FetchAPI = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(async (response) => {
@@ -3110,11 +3272,11 @@ export const AccountsApiFactory = function (configuration: Configuration) {
          * Creates a new account
          * @summary Create a new account
          * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-         * @param {SaveAccountWrapper} data - The account to create.
+         * @param {PostAccountWrapper} data - The account to create.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        createAccount(budget_id: string, data: SaveAccountWrapper, options?: any) {
+        createAccount(budget_id: string, data: PostAccountWrapper, options?: any) {
             return AccountsApiFp(configuration).createAccount(budget_id, data, options)();
         },
         /**
@@ -3153,12 +3315,12 @@ export class AccountsApi extends BaseAPI {
      * Creates a new account
      * @summary Create a new account
      * @param {string} budget_id - The id of the budget (\"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget)
-     * @param {SaveAccountWrapper} data - The account to create.
+     * @param {PostAccountWrapper} data - The account to create.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
-    public createAccount(budget_id: string, data: SaveAccountWrapper, options?: any) {
+    public createAccount(budget_id: string, data: PostAccountWrapper, options?: any) {
         return AccountsApiFp(this.configuration).createAccount(budget_id, data, options)();
     }
 
@@ -3211,7 +3373,8 @@ export const BudgetsApiFetchParamCreator = function (configuration: Configuratio
             }
             const localVarPath = `/budgets/{budget_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3229,13 +3392,18 @@ export const BudgetsApiFetchParamCreator = function (configuration: Configuratio
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3253,7 +3421,8 @@ export const BudgetsApiFetchParamCreator = function (configuration: Configuratio
             }
             const localVarPath = `/budgets/{budget_id}/settings`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3267,13 +3436,18 @@ export const BudgetsApiFetchParamCreator = function (configuration: Configuratio
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3286,7 +3460,8 @@ export const BudgetsApiFetchParamCreator = function (configuration: Configuratio
          */
         getBudgets(include_accounts?: boolean, options: any = {}): FetchArgs {
             const localVarPath = `/budgets`;
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3304,13 +3479,18 @@ export const BudgetsApiFetchParamCreator = function (configuration: Configuratio
                 localVarQueryParameter['include_accounts'] = include_accounts;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3503,7 +3683,8 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
             }
             const localVarPath = `/budgets/{budget_id}/categories`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3521,13 +3702,18 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3551,7 +3737,8 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
             const localVarPath = `/budgets/{budget_id}/categories/{category_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3565,13 +3752,18 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3601,7 +3793,8 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"month"}}`, encodeURIComponent(convertDateToFullDateStringFormat(month)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3615,13 +3808,18 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3631,11 +3829,11 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
          * @param {string} category_id - The id of the category
-         * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+         * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options: any = {}): FetchArgs {
+        updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options: any = {}): FetchArgs {
             // verify required parameter 'budget_id' is not null or undefined
             if (budget_id === null || budget_id === undefined) {
                 throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling updateMonthCategory.');
@@ -3656,7 +3854,8 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"month"}}`, encodeURIComponent(convertDateToFullDateStringFormat(month)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'PATCH' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3672,14 +3871,19 @@ export const CategoriesApiFetchParamCreator = function (configuration: Configura
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -3771,11 +3975,11 @@ export const CategoriesApiFp = function(configuration: Configuration) {
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
          * @param {string} category_id - The id of the category
-         * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+         * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<SaveCategoryResponse & { rateLimit: string | null }> {
+        updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<SaveCategoryResponse & { rateLimit: string | null }> {
             const localVarFetchArgs = CategoriesApiFetchParamCreator(configuration).updateMonthCategory(budget_id, month, category_id, data, options);
             return (fetchFunction: FetchAPI = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(async (response) => {
@@ -3840,11 +4044,11 @@ export const CategoriesApiFactory = function (configuration: Configuration) {
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
          * @param {string} category_id - The id of the category
-         * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+         * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any) {
+        updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any) {
             return CategoriesApiFp(configuration).updateMonthCategory(budget_id, month, category_id, data, options)();
         },
     };
@@ -3903,12 +4107,12 @@ export class CategoriesApi extends BaseAPI {
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {Date} month - The budget month in ISO format (e.g. 2016-12-01) (\"current\" can also be used to specify the current calendar month (UTC))
      * @param {string} category_id - The id of the category
-     * @param {SaveMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
+     * @param {PatchMonthCategoryWrapper} data - The category to update.  Only `budgeted` amount can be updated and any other fields specified will be ignored.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof CategoriesApi
      */
-    public updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: SaveMonthCategoryWrapper, options?: any) {
+    public updateMonthCategory(budget_id: string, month: Date | string, category_id: string, data: PatchMonthCategoryWrapper, options?: any) {
         return CategoriesApiFp(this.configuration).updateMonthCategory(budget_id, month, category_id, data, options)();
     }
 
@@ -3939,7 +4143,8 @@ export const DeprecatedApiFetchParamCreator = function (configuration: Configura
             }
             const localVarPath = `/budgets/{budget_id}/transactions/bulk`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -3955,14 +4160,19 @@ export const DeprecatedApiFetchParamCreator = function (configuration: Configura
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(transactions || {});
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4070,7 +4280,8 @@ export const MonthsApiFetchParamCreator = function (configuration: Configuration
             const localVarPath = `/budgets/{budget_id}/months/{month}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"month"}}`, encodeURIComponent(convertDateToFullDateStringFormat(month)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4084,13 +4295,18 @@ export const MonthsApiFetchParamCreator = function (configuration: Configuration
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4109,7 +4325,8 @@ export const MonthsApiFetchParamCreator = function (configuration: Configuration
             }
             const localVarPath = `/budgets/{budget_id}/months`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4127,13 +4344,18 @@ export const MonthsApiFetchParamCreator = function (configuration: Configuration
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4289,7 +4511,8 @@ export const PayeeLocationsApiFetchParamCreator = function (configuration: Confi
             const localVarPath = `/budgets/{budget_id}/payee_locations/{payee_location_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_location_id"}}`, encodeURIComponent(String(payee_location_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4303,13 +4526,18 @@ export const PayeeLocationsApiFetchParamCreator = function (configuration: Confi
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4327,7 +4555,8 @@ export const PayeeLocationsApiFetchParamCreator = function (configuration: Confi
             }
             const localVarPath = `/budgets/{budget_id}/payee_locations`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4341,13 +4570,18 @@ export const PayeeLocationsApiFetchParamCreator = function (configuration: Confi
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4371,7 +4605,8 @@ export const PayeeLocationsApiFetchParamCreator = function (configuration: Confi
             const localVarPath = `/budgets/{budget_id}/payees/{payee_id}/payee_locations`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_id"}}`, encodeURIComponent(String(payee_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4385,13 +4620,18 @@ export const PayeeLocationsApiFetchParamCreator = function (configuration: Confi
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4592,7 +4832,8 @@ export const PayeesApiFetchParamCreator = function (configuration: Configuration
             const localVarPath = `/budgets/{budget_id}/payees/{payee_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_id"}}`, encodeURIComponent(String(payee_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4606,13 +4847,18 @@ export const PayeesApiFetchParamCreator = function (configuration: Configuration
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4631,7 +4877,8 @@ export const PayeesApiFetchParamCreator = function (configuration: Configuration
             }
             const localVarPath = `/budgets/{budget_id}/payees`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4649,13 +4896,18 @@ export const PayeesApiFetchParamCreator = function (configuration: Configuration
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4811,7 +5063,8 @@ export const ScheduledTransactionsApiFetchParamCreator = function (configuration
             const localVarPath = `/budgets/{budget_id}/scheduled_transactions/{scheduled_transaction_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"scheduled_transaction_id"}}`, encodeURIComponent(String(scheduled_transaction_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4825,13 +5078,18 @@ export const ScheduledTransactionsApiFetchParamCreator = function (configuration
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -4850,7 +5108,8 @@ export const ScheduledTransactionsApiFetchParamCreator = function (configuration
             }
             const localVarPath = `/budgets/{budget_id}/scheduled_transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -4868,13 +5127,18 @@ export const ScheduledTransactionsApiFetchParamCreator = function (configuration
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5014,11 +5278,11 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
          * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
          * @summary Create a single transaction or multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+         * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        createTransaction(budget_id: string, data: SaveTransactionsWrapper, options: any = {}): FetchArgs {
+        createTransaction(budget_id: string, data: PostTransactionsWrapper, options: any = {}): FetchArgs {
             // verify required parameter 'budget_id' is not null or undefined
             if (budget_id === null || budget_id === undefined) {
                 throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling createTransaction.');
@@ -5029,7 +5293,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             }
             const localVarPath = `/budgets/{budget_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5045,14 +5310,69 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Deletes a transaction
+         * @summary Deletes an existing transaction
+         * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+         * @param {string} transaction_id - The id of the transaction
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        deleteTransaction(budget_id: string, transaction_id: string, options: any = {}): FetchArgs {
+            // verify required parameter 'budget_id' is not null or undefined
+            if (budget_id === null || budget_id === undefined) {
+                throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling deleteTransaction.');
+            }
+            // verify required parameter 'transaction_id' is not null or undefined
+            if (transaction_id === null || transaction_id === undefined) {
+                throw new RequiredError('transaction_id','Required parameter transaction_id was null or undefined when calling deleteTransaction.');
+            }
+            const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
+                .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
+                .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            const localVarRequestOptions = Object.assign({ method: 'DELETE' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["User-Agent"] = USER_AGENT;
+            localVarHeaderParameter["Accept"] = "application/json";
+
+            // authentication bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5076,7 +5396,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5090,13 +5411,18 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5117,7 +5443,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             }
             const localVarPath = `/budgets/{budget_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5143,13 +5470,18 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5176,7 +5508,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             const localVarPath = `/budgets/{budget_id}/accounts/{account_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"account_id"}}`, encodeURIComponent(String(account_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5202,13 +5535,18 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5235,7 +5573,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             const localVarPath = `/budgets/{budget_id}/categories/{category_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"category_id"}}`, encodeURIComponent(String(category_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5261,13 +5600,18 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5294,7 +5638,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             const localVarPath = `/budgets/{budget_id}/payees/{payee_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"payee_id"}}`, encodeURIComponent(String(payee_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5320,13 +5665,18 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
                 localVarQueryParameter['last_knowledge_of_server'] = last_knowledge_of_server;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5344,7 +5694,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             }
             const localVarPath = `/budgets/{budget_id}/transactions/import`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5358,13 +5709,18 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5373,11 +5729,11 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
          * @summary Updates an existing transaction
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {string} transaction_id - The id of the transaction
-         * @param {SaveTransactionWrapper} data - The transaction to update
+         * @param {PutTransactionWrapper} data - The transaction to update
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options: any = {}): FetchArgs {
+        updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options: any = {}): FetchArgs {
             // verify required parameter 'budget_id' is not null or undefined
             if (budget_id === null || budget_id === undefined) {
                 throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling updateTransaction.');
@@ -5393,7 +5749,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             const localVarPath = `/budgets/{budget_id}/transactions/{transaction_id}`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)))
                 .replace(`{${"transaction_id"}}`, encodeURIComponent(String(transaction_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'PUT' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5409,14 +5766,19 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5424,11 +5786,11 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
          * Updates multiple transactions, by `id` or `import_id`.
          * @summary Update multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+         * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options: any = {}): FetchArgs {
+        updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options: any = {}): FetchArgs {
             // verify required parameter 'budget_id' is not null or undefined
             if (budget_id === null || budget_id === undefined) {
                 throw new RequiredError('budget_id','Required parameter budget_id was null or undefined when calling updateTransactions.');
@@ -5439,7 +5801,8 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
             }
             const localVarPath = `/budgets/{budget_id}/transactions`
                 .replace(`{${"budget_id"}}`, encodeURIComponent(String(budget_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'PATCH' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5455,14 +5818,19 @@ export const TransactionsApiFetchParamCreator = function (configuration: Configu
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             localVarRequestOptions.body = JSON.stringify(data || {});
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },
@@ -5479,16 +5847,40 @@ export const TransactionsApiFp = function(configuration: Configuration) {
          * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
          * @summary Create a single transaction or multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+         * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<SaveTransactionsResponse & { rateLimit: string | null }> {
+        createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<SaveTransactionsResponse & { rateLimit: string | null }> {
             const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).createTransaction(budget_id, data, options);
             return (fetchFunction: FetchAPI = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(async (response) => {
                     if (response.status >= 200 && response.status < 300) {
                         const apiResponse: SaveTransactionsResponse & { rateLimit: string | null } = await response.json();
+                        apiResponse.rateLimit = response.headers.get("X-Rate-Limit");
+                        return apiResponse;
+                    } else {
+                        return response.json().then((e) => {
+                            return Promise.reject(e);
+                        });
+                    }
+                });
+            };
+        },
+        /**
+         * Deletes a transaction
+         * @summary Deletes an existing transaction
+         * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+         * @param {string} transaction_id - The id of the transaction
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        deleteTransaction(budget_id: string, transaction_id: string, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse & { rateLimit: string | null }> {
+            const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).deleteTransaction(budget_id, transaction_id, options);
+            return (fetchFunction: FetchAPI = fetch) => {
+                return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(async (response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        const apiResponse: TransactionResponse & { rateLimit: string | null } = await response.json();
                         apiResponse.rateLimit = response.headers.get("X-Rate-Limit");
                         return apiResponse;
                     } else {
@@ -5658,11 +6050,11 @@ export const TransactionsApiFp = function(configuration: Configuration) {
          * @summary Updates an existing transaction
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {string} transaction_id - The id of the transaction
-         * @param {SaveTransactionWrapper} data - The transaction to update
+         * @param {PutTransactionWrapper} data - The transaction to update
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse & { rateLimit: string | null }> {
+        updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<TransactionResponse & { rateLimit: string | null }> {
             const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).updateTransaction(budget_id, transaction_id, data, options);
             return (fetchFunction: FetchAPI = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(async (response) => {
@@ -5682,11 +6074,11 @@ export const TransactionsApiFp = function(configuration: Configuration) {
          * Updates multiple transactions, by `id` or `import_id`.
          * @summary Update multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+         * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<SaveTransactionsResponse & { rateLimit: string | null }> {
+        updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any): (fetchFunction?: FetchAPI) => Promise<SaveTransactionsResponse & { rateLimit: string | null }> {
             const localVarFetchArgs = TransactionsApiFetchParamCreator(configuration).updateTransactions(budget_id, data, options);
             return (fetchFunction: FetchAPI = fetch) => {
                 return fetchFunction(configuration.basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(async (response) => {
@@ -5715,12 +6107,23 @@ export const TransactionsApiFactory = function (configuration: Configuration) {
          * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
          * @summary Create a single transaction or multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+         * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any) {
+        createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any) {
             return TransactionsApiFp(configuration).createTransaction(budget_id, data, options)();
+        },
+        /**
+         * Deletes a transaction
+         * @summary Deletes an existing transaction
+         * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+         * @param {string} transaction_id - The id of the transaction
+         * @param {*} [options] - Override http request options.
+         * @throws {RequiredError}
+         */
+        deleteTransaction(budget_id: string, transaction_id: string, options?: any) {
+            return TransactionsApiFp(configuration).deleteTransaction(budget_id, transaction_id, options)();
         },
         /**
          * Returns a single transaction
@@ -5803,22 +6206,22 @@ export const TransactionsApiFactory = function (configuration: Configuration) {
          * @summary Updates an existing transaction
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
          * @param {string} transaction_id - The id of the transaction
-         * @param {SaveTransactionWrapper} data - The transaction to update
+         * @param {PutTransactionWrapper} data - The transaction to update
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any) {
+        updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any) {
             return TransactionsApiFp(configuration).updateTransaction(budget_id, transaction_id, data, options)();
         },
         /**
          * Updates multiple transactions, by `id` or `import_id`.
          * @summary Update multiple transactions
          * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-         * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+         * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
          * @param {*} [options] - Override http request options.
          * @throws {RequiredError}
          */
-        updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any) {
+        updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any) {
             return TransactionsApiFp(configuration).updateTransactions(budget_id, data, options)();
         },
     };
@@ -5835,13 +6238,26 @@ export class TransactionsApi extends BaseAPI {
      * Creates a single transaction or multiple transactions.  If you provide a body containing a `transaction` object, a single transaction will be created and if you provide a body containing a `transactions` array, multiple transactions will be created.  Scheduled transactions cannot be created on this endpoint.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {SaveTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
+     * @param {PostTransactionsWrapper} data - The transaction or transactions to create.  To create a single transaction you can specify a value for the `transaction` object and to create multiple transactions you can specify an array of `transactions`.  It is expected that you will only provide a value for one of these objects.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    public createTransaction(budget_id: string, data: SaveTransactionsWrapper, options?: any) {
+    public createTransaction(budget_id: string, data: PostTransactionsWrapper, options?: any) {
         return TransactionsApiFp(this.configuration).createTransaction(budget_id, data, options)();
+    }
+
+    /**
+     * Deletes a transaction
+     * @summary Deletes an existing transaction
+     * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
+     * @param {string} transaction_id - The id of the transaction
+     * @param {*} [options] - Override http request options.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    public deleteTransaction(budget_id: string, transaction_id: string, options?: any) {
+        return TransactionsApiFp(this.configuration).deleteTransaction(budget_id, transaction_id, options)();
     }
 
     /**
@@ -5937,12 +6353,12 @@ export class TransactionsApi extends BaseAPI {
      * @summary Updates an existing transaction
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
      * @param {string} transaction_id - The id of the transaction
-     * @param {SaveTransactionWrapper} data - The transaction to update
+     * @param {PutTransactionWrapper} data - The transaction to update
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    public updateTransaction(budget_id: string, transaction_id: string, data: SaveTransactionWrapper, options?: any) {
+    public updateTransaction(budget_id: string, transaction_id: string, data: PutTransactionWrapper, options?: any) {
         return TransactionsApiFp(this.configuration).updateTransaction(budget_id, transaction_id, data, options)();
     }
 
@@ -5950,12 +6366,12 @@ export class TransactionsApi extends BaseAPI {
      * Updates multiple transactions, by `id` or `import_id`.
      * @summary Update multiple transactions
      * @param {string} budget_id - The id of the budget. \"last-used\" can be used to specify the last used budget and \"default\" can be used if default budget selection is enabled (see: https://api.youneedabudget.com/#oauth-default-budget).
-     * @param {UpdateTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
+     * @param {PatchTransactionsWrapper} data - The transactions to update. Each transaction must have either an `id` or `import_id` specified. If `id` is specified as null an `import_id` value can be provided which will allow transaction(s) to be updated by their `import_id`. If an `id` is specified, it will always be used for lookup.
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    public updateTransactions(budget_id: string, data: UpdateTransactionsWrapper, options?: any) {
+    public updateTransactions(budget_id: string, data: PatchTransactionsWrapper, options?: any) {
         return TransactionsApiFp(this.configuration).updateTransactions(budget_id, data, options)();
     }
 
@@ -5975,7 +6391,8 @@ export const UserApiFetchParamCreator = function (configuration: Configuration) 
          */
         getUser(options: any = {}): FetchArgs {
             const localVarPath = `/user`;
-            const localVarUrlObj = url.parse(localVarPath, true);
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
@@ -5989,13 +6406,18 @@ export const UserApiFetchParamCreator = function (configuration: Configuration) 
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
 
             return {
-                url: url.format(localVarUrlObj),
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
                 options: localVarRequestOptions,
             };
         },

--- a/src/transactionsApi.ts
+++ b/src/transactionsApi.ts
@@ -37,7 +37,7 @@ export class TransactionsApi extends CodeGen.TransactionsApi {
    */
   public createTransactions(
     budget_id: string,
-    data: CodeGen.SaveTransactionsWrapper,
+    data: CodeGen.PostTransactionsWrapper,
     options?: any
   ) {
     return CodeGen.TransactionsApiFp(this.configuration).createTransaction(

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -83,7 +83,7 @@ export const saveAccountFactory = Factory.makeFactory<api.SaveAccount>({
 });
 
 export const saveAccountWrapperFactory =
-  Factory.makeFactory<api.SaveAccountWrapper>({
+  Factory.makeFactory<api.PostAccountWrapper>({
     account: saveAccountFactory.build(),
   });
 
@@ -344,18 +344,24 @@ export const saveTransactionFactory = Factory.makeFactory<api.SaveTransaction>({
   import_id: null!,
 });
 
+
 export const saveSingleTransactionWrapperFactory =
-  Factory.makeFactory<api.SaveTransactionWrapper>({
+  Factory.makeFactory<api.PostTransactionsWrapper>({
+    transaction: saveTransactionFactory.build(),
+  });
+
+  export const updateSingleTransactionWrapperFactory =
+  Factory.makeFactory<api.PutTransactionWrapper>({
     transaction: saveTransactionFactory.build(),
   });
 
 export const saveMultipleTransactionsWrapperFactory =
-  Factory.makeFactory<api.SaveTransactionsWrapper>({
+  Factory.makeFactory<api.PostTransactionsWrapper>({
     transactions: saveTransactionFactory.buildList(3),
   });
 
 export const updateTransactionFactory =
-  Factory.makeFactory<api.UpdateTransaction>({
+  Factory.makeFactory<api.SaveTransactionWithId>({
     id: "3045b6ae-4684-4df5-8ade-9f116975688f",
     account_id: Factory.each((i) => `account_id #${i}`),
     date: "2017-01-02",
@@ -371,7 +377,7 @@ export const updateTransactionFactory =
   });
 
 export const updateMultipleTransactionsWrapperFactory =
-  Factory.makeFactory<api.UpdateTransactionsWrapper>({
+  Factory.makeFactory<api.PatchTransactionsWrapper>({
     transactions: updateTransactionFactory.buildList(3),
   });
 

--- a/test/requestTests.ts
+++ b/test/requestTests.ts
@@ -32,7 +32,7 @@ describe("API requests", () => {
     it("Should get user", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.user.getUser(),
         factories.userResponseFactory.build()
       );
@@ -92,7 +92,7 @@ describe("API requests", () => {
     it("Should getAccounts and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.accounts.getAccounts(budgetId),
         factories.accountsResponseFactory.build()
       );
@@ -103,7 +103,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const accountId = "DummyAccountId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.accounts.getAccountById(budgetId, accountId),
         factories.accountResponseFactory.build()
       );
@@ -115,7 +115,7 @@ describe("API requests", () => {
     it("Should create account", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.accounts.createAccount(
             budgetId,
@@ -137,7 +137,7 @@ describe("API requests", () => {
 
       const budgetId = "/://{}?";
       const accountId = "/://{}?";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.accounts.getAccountById(budgetId, accountId),
         factories.accountResponseFactory.build()
       );
@@ -155,7 +155,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const accountId = "DummyAccountId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.categories.getCategories(budgetId),
         mockResponse
       );
@@ -166,7 +166,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const categoryId = "DummyCategoryId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.categories.getCategoryById(budgetId, categoryId),
         factories.categoryResponseFactory.build()
       );
@@ -180,7 +180,7 @@ describe("API requests", () => {
     it("Should getBudgetMonths and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonths(budgetId),
         factories.monthSummariesResponseFactory.build()
       );
@@ -191,7 +191,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const budgetMonth = getUTCDate(2017, 1, 1);
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonth(budgetId, budgetMonth),
         factories.monthDetailResponseFactory.build()
       );
@@ -201,7 +201,7 @@ describe("API requests", () => {
     it("Should getBudgetMonth with a string param and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonth(budgetId, "2017-01"),
         factories.monthDetailResponseFactory.build()
       );
@@ -211,7 +211,7 @@ describe("API requests", () => {
     it("Should getBudgetMonth with a string param of 'current' and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.months.getBudgetMonth(budgetId, "current"),
         factories.monthDetailResponseFactory.build()
       );
@@ -223,7 +223,7 @@ describe("API requests", () => {
     it("Should getPayees and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.payees.getPayees(budgetId),
         factories.payeesResponseFactory.build()
       );
@@ -234,7 +234,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const payeeId = "payeeId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.payees.getPayeeById(budgetId, payeeId),
         factories.payeeResponseFactory.build()
       );
@@ -246,7 +246,7 @@ describe("API requests", () => {
     it("Should getPayeeLocations and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.payeeLocations.getPayeeLocations(budgetId),
         factories.payeeLocationsResponseFactory.build()
       );
@@ -257,7 +257,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const payeeLocationId = "payeeLocationId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.payeeLocations.getPayeeLocationById(
             budgetId,
@@ -275,7 +275,7 @@ describe("API requests", () => {
     it("Should getTransactions and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.transactions.getTransactions(budgetId),
         factories.transactionsResponseFactory.build()
       );
@@ -285,7 +285,7 @@ describe("API requests", () => {
     it("Should getTransactionsByType and validate the request is sent correctly", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.getTransactionsByType(budgetId, "uncategorized"),
         factories.transactionsResponseFactory.build()
@@ -299,7 +299,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const transactionId = "TransactionId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () => ynabAPI.transactions.getTransactionById(budgetId, transactionId),
         factories.transactionResponseFactory.build()
       );
@@ -313,7 +313,7 @@ describe("API requests", () => {
 
       const accountId = "accountId";
       const sinceDate = getUTCDate(2017, 1, 1);
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.getTransactionsByAccount(
             budgetId,
@@ -332,7 +332,7 @@ describe("API requests", () => {
 
       const accountId = "accountId";
       const sinceDate = "2017-02";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.getTransactionsByAccount(
             budgetId,
@@ -351,7 +351,7 @@ describe("API requests", () => {
 
       const categoryId = "categoryId";
       const sinceDate = getUTCDate(2017, 1, 1);
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.getTransactionsByCategory(
             budgetId,
@@ -371,7 +371,7 @@ describe("API requests", () => {
       const categoryId = "categoryId";
       // Make sure we can pass a string as well
       const sinceDate = "2017-03";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.getTransactionsByCategory(
             budgetId,
@@ -385,10 +385,9 @@ describe("API requests", () => {
       );
     });
 
-    it("Should createTransaction", async () => {
+    it("Should create a transaction", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
-
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.createTransaction(
             budgetId,
@@ -407,8 +406,7 @@ describe("API requests", () => {
 
     it("Should create multple transactions", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
-
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.createTransaction(
             budgetId,
@@ -427,8 +425,7 @@ describe("API requests", () => {
 
     it("Should create multple transactions via alias", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
-
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.createTransactions(
             budgetId,
@@ -445,15 +442,15 @@ describe("API requests", () => {
       );
     });
 
-    it("Should updateTransaction", async () => {
+    it("Should update a transaction", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
       const transactionId = "B5F12BF2-AFCD-4447-BE3E-1855D3B23ECC";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.updateTransaction(
             budgetId,
             transactionId,
-            factories.saveSingleTransactionWrapperFactory.build()
+            factories.updateSingleTransactionWrapperFactory.build()
           ),
         factories.transactionResponseFactory.build()
       );
@@ -468,8 +465,7 @@ describe("API requests", () => {
 
     it("Should update multiple transactions", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
-      const transactionId = "B5F12BF2-AFCD-4447-BE3E-1855D3B23ECC";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.updateTransactions(
             budgetId,
@@ -501,10 +497,10 @@ describe("API requests", () => {
       );
     });
 
-    it("Should bulkCreateTransactions", async () => {
+    it("Should bulk create transactions", async () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
       const transactionId = "B5F12BF2-AFCD-4447-BE3E-1855D3B23ECC";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.transactions.bulkCreateTransactions(
             budgetId,
@@ -518,6 +514,22 @@ describe("API requests", () => {
         API_KEY,
         1,
         "POST"
+      );
+    });
+
+    it("Should delete a transaction ", async () => {
+      const ynabAPI = new ynab.API(API_KEY, BASE_URL);
+      const transactionId = "B5F12BF2-AFCD-4447-BE3E-1855D3B23ECC";
+      await callApiAndVerifyResponse(
+        () => ynabAPI.transactions.deleteTransaction(budgetId, transactionId),
+        factories.transactionResponseFactory.build()
+      );
+
+      verifyRequestDetails(
+        `${BASE_URL}/budgets/${budgetId}/transactions/${transactionId}`,
+        API_KEY,
+        1,
+        "DELETE"
       );
     });
   });
@@ -539,7 +551,7 @@ describe("API requests", () => {
       const ynabAPI = new ynab.API(API_KEY, BASE_URL);
 
       const scheduledTransactionId = "scheduledTransactionId";
-      const returnedResponse = await callApiAndVerifyResponse(
+      await callApiAndVerifyResponse(
         () =>
           ynabAPI.scheduledTransactions.getScheduledTransactionById(
             budgetId,
@@ -558,7 +570,10 @@ async function callApiAndVerifyResponse<ResponseType>(
   promiseFunc: () => Promise<ResponseType>,
   mockResponse: ResponseType
 ) {
-  fetchMock.once("*", { body: mockResponse, headers: { "X-Rate-Limit": "1/200" }});
+  fetchMock.once("*", {
+    body: mockResponse,
+    headers: { "X-Rate-Limit": "1/200" },
+  });
   let actualResponse = await promiseFunc();
   expect(actualResponse).to.deep.equal(mockResponse);
   return actualResponse;
@@ -568,7 +583,7 @@ function verifyRequestDetails(
   url: string,
   bearerTokenExpected: string = API_KEY,
   numCalls: number = 1,
-  method: "GET" | "POST" | "PUT" | "PATCH" = "GET"
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" = "GET"
 ) {
   // TODO: Lastest version of @types/fetch-mock has incorrect type for calls(); once updated, remove this forced cast
   const calls = <Array<string>>(<any>fetchMock.calls());


### PR DESCRIPTION
In this PR:
- Upgrade to TyeScript 4.5.5
- Regenerate client from latest spec:
  - `DELETE /budgets/:id/transactions/:id` - new
  - `PATCH  /budgets/:id/transactions/:id` - no longer _require_ `account_id`, `date`, or `amount` when patching transactions
- Misc cleanup
- New examples 