### PR TITLE
Add more fields to account, category, and transaction resources

### DIFF
--- a/.swagger-codegen/config.json
+++ b/.swagger-codegen/config.json
@@ -1,5 +1,5 @@
 {
   "npmName": "ynab",
-  "npmVersion": "1.42.0",
+  "npmVersion": "1.45.0",
   "supportsES6": true
 }

--- a/.swagger-codegen/spec-v1-swagger.json
+++ b/.swagger-codegen/spec-v1-swagger.json
@@ -1879,6 +1879,28 @@
           "type": "boolean",
           "description": "If an account linked to a financial institution (direct_import_linked=true) and the linked connection is not in a healthy state, this will be true."
         },
+        "last_reconciled_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "A date/time specifying when the account was last reconciled."
+        },
+        "debt_original_balance": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The original debt/loan account balance, specified in milliunits format."
+        },
+        "debt_interest_rates": {
+          "$ref": "#/definitions/LoanAccountPeriodicValue",
+          "description": "The debt/loan account interest rate(s), by effective date."
+        },
+        "debt_minimum_payments": {
+          "$ref": "#/definitions/LoanAccountPeriodicValue",
+          "description": "The minimum payment amount(s) for the debt/loan account, by effective date.  The amounts are specified in milliunits format."
+        },
+        "debt_escrow_amounts": {
+          "$ref": "#/definitions/LoanAccountPeriodicValue",
+          "description": "The escrow value(s) for the debt/loan account, by effective date.  The amounts are specified in milliunits format."
+        },
         "deleted": {
           "type": "boolean",
           "description": "Whether or not the account has been deleted.  Deleted accounts will only be included in delta requests."
@@ -1910,6 +1932,13 @@
           "format": "int64",
           "description": "The current balance of the account in milliunits format"
         }
+      }
+    },
+    "LoanAccountPeriodicValue": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "int64"
       }
     },
     "AccountType": {
@@ -2056,6 +2085,21 @@
           "type": "string",
           "enum": ["TB", "TBD", "MF", "NEED", "DEBT", null],
           "description": "The type of goal, if the category has a goal (TB='Target Category Balance', TBD='Target Category Balance by Date', MF='Monthly Funding', NEED='Plan Your Spending')"
+        },
+        "goal_day": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The day of the goal"
+        },
+        "goal_cadence": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The goal cadence"
+        },
+        "goal_cadence_frequency": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The goal cadence frequency"
         },
         "goal_creation_month": {
           "type": "string",
@@ -2568,6 +2612,21 @@
           "type": "string",
           "maxLength": 200,
           "description": "If the transaction was imported, the original payee name as it appeared on the statement"
+        },
+        "debt_transaction_type": {
+          "type": "string",
+          "enum": [
+            "payment",
+            "refund",
+            "fee",
+            "interest",
+            "escrow",
+            "balancedAdjustment",
+            "credit",
+            "charge",
+            null
+          ],
+          "description": "If the transaction is a debt/loan account transaction, the type of transaction"
         },
         "deleted": {
           "type": "boolean",

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,7 @@ if (!globalThis.fetch) {
 import * as url from "url";
 import { Configuration } from "./configuration";
 
-const USER_AGENT = "api_client/js/1.42.0";
+const USER_AGENT = "api_client/js/1.45.0";
 
 function convertDateToFullDateStringFormat(date: Date | string): string {
   // Convert to RFC 3339 "full-date" format, like "2017-11-27"
@@ -171,6 +171,36 @@ export interface Account {
      * @memberof Account
      */
     direct_import_in_error?: boolean | null;
+    /**
+     * A date/time specifying when the account was last reconciled.
+     * @type {string}
+     * @memberof Account
+     */
+    last_reconciled_at?: string | null;
+    /**
+     * The original debt/loan account balance, specified in milliunits format.
+     * @type {number}
+     * @memberof Account
+     */
+    debt_original_balance?: number | null;
+    /**
+     * The debt/loan account interest rate(s), by effective date.
+     * @type {LoanAccountPeriodicValue}
+     * @memberof Account
+     */
+    debt_interest_rates?: LoanAccountPeriodicValue | null;
+    /**
+     * The minimum payment amount(s) for the debt/loan account, by effective date.  The amounts are specified in milliunits format.
+     * @type {LoanAccountPeriodicValue}
+     * @memberof Account
+     */
+    debt_minimum_payments?: LoanAccountPeriodicValue | null;
+    /**
+     * The escrow value(s) for the debt/loan account, by effective date.  The amounts are specified in milliunits format.
+     * @type {LoanAccountPeriodicValue}
+     * @memberof Account
+     */
+    debt_escrow_amounts?: LoanAccountPeriodicValue | null;
     /**
      * Whether or not the account has been deleted.  Deleted accounts will only be included in delta requests.
      * @type {boolean}
@@ -597,6 +627,24 @@ export interface Category {
      */
     goal_type?: Category.GoalTypeEnum | null;
     /**
+     * The day of the goal
+     * @type {number}
+     * @memberof Category
+     */
+    goal_day?: number | null;
+    /**
+     * The goal cadence
+     * @type {number}
+     * @memberof Category
+     */
+    goal_cadence?: number | null;
+    /**
+     * The goal cadence frequency
+     * @type {number}
+     * @memberof Category
+     */
+    goal_cadence_frequency?: number | null;
+    /**
      * The month a goal was created
      * @type {string}
      * @memberof Category
@@ -872,6 +920,16 @@ export interface HybridTransactionsResponseData {
      * @memberof HybridTransactionsResponseData
      */
     server_knowledge?: number | null;
+}
+
+/**
+ * 
+ * @export
+ * @interface LoanAccountPeriodicValue
+ */
+export interface LoanAccountPeriodicValue {
+    [key: string]: number;
+
 }
 
 /**
@@ -1969,6 +2027,12 @@ export interface TransactionSummary {
      */
     import_payee_name_original?: string | null;
     /**
+     * If the transaction is a debt/loan account transaction, the type of transaction
+     * @type {string}
+     * @memberof TransactionSummary
+     */
+    debt_transaction_type?: TransactionSummary.DebtTransactionTypeEnum | null;
+    /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
      * @memberof TransactionSummary
@@ -2001,6 +2065,20 @@ export namespace TransactionSummary {
         Green = <any> 'green',
         Blue = <any> 'blue',
         Purple = <any> 'purple'
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum DebtTransactionTypeEnum {
+        Payment = <any> 'payment',
+        Refund = <any> 'refund',
+        Fee = <any> 'fee',
+        Interest = <any> 'interest',
+        Escrow = <any> 'escrow',
+        BalancedAdjustment = <any> 'balancedAdjustment',
+        Credit = <any> 'credit',
+        Charge = <any> 'charge'
     }
 }
 
@@ -2359,6 +2437,12 @@ export interface HybridTransaction {
      */
     import_payee_name_original?: string | null;
     /**
+     * If the transaction is a debt/loan account transaction, the type of transaction
+     * @type {string}
+     * @memberof HybridTransaction
+     */
+    debt_transaction_type?: HybridTransaction.DebtTransactionTypeEnum | null;
+    /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
      * @memberof HybridTransaction
@@ -2421,6 +2505,20 @@ export namespace HybridTransaction {
         Green = <any> 'green',
         Blue = <any> 'blue',
         Purple = <any> 'purple'
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum DebtTransactionTypeEnum {
+        Payment = <any> 'payment',
+        Refund = <any> 'refund',
+        Fee = <any> 'fee',
+        Interest = <any> 'interest',
+        Escrow = <any> 'escrow',
+        BalancedAdjustment = <any> 'balancedAdjustment',
+        Credit = <any> 'credit',
+        Charge = <any> 'charge'
     }
     /**
      * @export
@@ -2961,6 +3059,12 @@ export interface TransactionDetail {
      */
     import_payee_name_original?: string | null;
     /**
+     * If the transaction is a debt/loan account transaction, the type of transaction
+     * @type {string}
+     * @memberof TransactionDetail
+     */
+    debt_transaction_type?: TransactionDetail.DebtTransactionTypeEnum | null;
+    /**
      * Whether or not the transaction has been deleted.  Deleted transactions will only be included in delta requests.
      * @type {boolean}
      * @memberof TransactionDetail
@@ -3017,6 +3121,20 @@ export namespace TransactionDetail {
         Green = <any> 'green',
         Blue = <any> 'blue',
         Purple = <any> 'purple'
+    }
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum DebtTransactionTypeEnum {
+        Payment = <any> 'payment',
+        Refund = <any> 'refund',
+        Fee = <any> 'fee',
+        Interest = <any> 'interest',
+        Escrow = <any> 'escrow',
+        BalancedAdjustment = <any> 'balancedAdjustment',
+        Credit = <any> 'credit',
+        Charge = <any> 'charge'
     }
 }
 


### PR DESCRIPTION
Regenerate the client from the latest spec which adds more fields to resources:

account resource:
- last_reconciled_at
- debt_original_balance
- debt_interest_rates
- debt_minimum_payments
- debt_escrow_amounts

category resource:
- goal_day
- goal_cadence
- goal_cadence_frequency

transaction resource:
- debt_transaction_type