### PR TITLE
Correct JSDoc param for TransactionsApi.createTransactions

### DIFF
--- a/dist/transactionsApi.d.ts
+++ b/dist/transactionsApi.d.ts
@@ -17,7 +17,7 @@ export declare class TransactionsApi extends CodeGen.TransactionsApi {
      * Creates multiple transactions. Provide a body containing a 'transactions' array, multiple transactions will be created.
      * @summary Create a single transaction or multiple transactions
      * @param {string} budget_id - The id of the budget (\"last-used\" can also be used to specify the last used budget)
-     * @param {SaveTransactionsWrapper} data - An object containing transactions to create
+     * @param {CodeGen.PostTransactionsWrapper} data - An object containing transactions to create
      * @param {*} [options] - Override http request options.
      * @throws {RequiredError}
      * @memberof TransactionsApi


### PR DESCRIPTION
It looks like the TS type was updated here but the JSDoc param type didn't follow, so updating this accordingly.