### PR TITLE
Modify GitHub Actions permissions in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,10 @@ on:
         - patch
 
 permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+  id-token: write # Required for OIDC
+  contents: write
+  issues: write
+  pull-requests: write  
 
 jobs:
   publish:


### PR DESCRIPTION
This pull request updates the permissions used in the `.github/workflows/publish.yml` workflow file to allow the workflow to write to repository contents, issues, and pull requests, rather than only reading contents.

Workflow permissions update:

* Changed the `permissions` for the publish workflow to include `contents: write`, `issues: write`, and `pull-requests: write` to enable broader write access as needed by the workflow.
 
In https://github.com/ynab/ynab-sdk-js/commit/0e0a50f465d9781f3440d0b94b337d645169bee7 permissions were changed to allow Trusted Publishers.  But, we need a few more permissions to be able to push version change commit and comment on issues / PRs.  The permissions are still tighter than the defaults.