### PR TITLE
Socket Basics SAST: add workflow and gitignore entries

### DIFF
--- a/.github/workflows/socket-basics.yml
+++ b/.github/workflows/socket-basics.yml
@@ -11,5 +11,4 @@ jobs:
     # Plus, the shared action does use pinned dependencies, and so will be updated fairly often.  When we do that, we do not
     # want to have to update the sha in every repo that uses this shared action, before such updates apply.
     uses: ynab/shared-actions/.github/workflows/socket-basics.yml@main
-    secrets:
-      SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+    secrets: inherit

--- a/.github/workflows/socket-basics.yml
+++ b/.github/workflows/socket-basics.yml
@@ -1,0 +1,15 @@
+name: Socket Basics Security Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  socket-basics-security-scan:
+    # We intentionally run this shared action from @main, not from a pinned sha
+    # this is because we control the shared-actions repo, so there is not a significant risk of malicious changes being pushed.
+    # Plus, the shared action does use pinned dependencies, and so will be updated fairly often.  When we do that, we do not
+    # want to have to update the sha in every repo that uses this shared action, before such updates apply.
+    uses: ynab/shared-actions/.github/workflows/socket-basics.yml@main
+    secrets:
+      SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 *.tsbuildinfo
+.socket-scans/
+.socket.facts.json

--- a/.socket-basics.json
+++ b/.socket-basics.json
@@ -1,3 +1,3 @@
 {
-  "javascript_disabled_rules": "js-code-injection-eval"
+  "javascript_disabled_rules": "js-code-injection-eval,js-hardcoded-secret"
 }

--- a/.socket-basics.json
+++ b/.socket-basics.json
@@ -1,0 +1,3 @@
+{
+  "javascript_disabled_rules": "js-code-injection-eval"
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/socket-basics.yml` — calls the shared Socket Basics reusable workflow at `@main`
- Adds `.socket-scans/` and `.socket.facts.json` to `.gitignore`
- Adds `.socket-basics.json` with repo-specific suppression rules

## Dependencies

Requires [ynab/shared-actions#233](https://github.com/ynab/shared-actions/pull/233) to be merged first.

## Test plan

- [x] Trigger on a PR — verify the `socket-basics-security-scan` job runs and posts a comment
- [x] Verify no unexpected findings block the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)