### PR TITLE
Socket Basics SAST: use explicit secrets instead of secrets: inherit

### DIFF
--- a/.github/workflows/socket-basics.yml
+++ b/.github/workflows/socket-basics.yml
@@ -11,4 +11,5 @@ jobs:
     # Plus, the shared action does use pinned dependencies, and so will be updated fairly often.  When we do that, we do not
     # want to have to update the sha in every repo that uses this shared action, before such updates apply.
     uses: ynab/shared-actions/.github/workflows/socket-basics.yml@main
-    secrets: inherit
+    secrets:
+      SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}


### PR DESCRIPTION
## Summary

- Replaces `secrets: inherit` with an explicit `SOCKET_SECURITY_API_KEY` secret
- `secrets: inherit` passes **all** secrets from the calling repo to shared-actions, violating least-privilege. Explicit secrets limit exposure to only what the workflow actually needs.

## Test plan

- [x] Confirm CI passes on a test PR after [shared-actions PR #242](https://github.com/ynab/shared-actions/pull/242) merges