### PR TITLE
Send Dependabot reviews to @bradymholt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
 # Paths that Dependabot PRs can touch
-/package.json @ynab/full-stack
-/package-lock.json @ynab/full-stack
-/.github/ @ynab/full-stack
+/package.json @bradymholt
+/package-lock.json @bradymholt
+/.github/ @bradymholt


### PR DESCRIPTION
Points the Dependabot paths at me instead of `@ynab/full-stack`. I'd like these dependency updates coming to me for the time being.

Matches what ynab-sdk-python already does.
