### PR TITLE
Publish: use the default `GITHUB_TOKEN` instead of a PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          token: ${{ secrets.GH_API_TOKEN }}
       - name: Setup git repo
-        env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
         run: |
           git config user.name $GITHUB_ACTOR
           git config user.email gh-actions-${GITHUB_ACTOR}@github.com


### PR DESCRIPTION
The publish workflow no longer needs the `GH_API_TOKEN` repo secret, so we can drop it.

The PAT was added back when the job pushed the `npm version` bump commit straight to `main`, which the `tier-1-repos` org ruleset blocks for the `github-actions` app. Since 16cba7a the job only runs `git push --tags`, and no ruleset or tag protection covers tags, so the default `GITHUB_TOKEN` with `contents: write` is enough. The `env` block on the "Setup git repo" step was already unused.

One thing worth a reviewer's eye: tag pushes made with `GITHUB_TOKEN` don't trigger workflows, so `build-test.yml` will stop firing on release tags. The publish job already runs the same tests.
