### PR TITLE
Bump version from 4.4.0 to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ynab",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ynab",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fetch-ponyfill": "^7.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Official JavaScript client for the YNAB API. API documentation available at https://api.ynab.com. Generated from server specification version 1.85.0",
   "author": "YNAB",
   "email": "api@ynab.com",


### PR DESCRIPTION
The latest published version is 4.5.0 and this change makes sure the `package.json` and `package-lock.json` files align with that.  A previous CI failure caused it to drift.

Refs:
- https://github.com/ynab/ynab-sdk-js/releases/tag/v4.5.0
- https://www.npmjs.com/package/ynab/v/4.5.0
