### PR TITLE
Set the release version in the repo instead of in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,6 @@
 name: Publish
 on:
   workflow_dispatch:
-    inputs:
-      version_type:
-        type: choice
-        description: Version type
-        default: minor
-        options:
-        - major
-        - minor
-        - patch
 
 permissions:
   id-token: write # Required for OIDC
@@ -30,20 +21,32 @@ jobs:
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
+      - name: Resolve version to publish
+        id: version
+        run: |
+          version=$(npm pkg get version | tr -d '"')
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "tag-name=v${version}" >> $GITHUB_OUTPUT
+      - name: Verify the release tag does not already exist
+        env:
+          TAG_NAME: ${{ steps.version.outputs.tag-name }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG_NAME} already exists. Bump the version in package.json first."
+            exit 1
+          fi
       - run: npm install
       - run: npm run build
       - run: npm run test
-      - name: Bump Version
-        run: |
-          git add dist/*
-          npm version ${{ github.event.inputs.version_type }} --force -m "Version %s"
       - name: Publish to npm
         run: npm publish
-      - name: Push release commit and tag to GitHub
-        id: push
+      - name: Tag the release commit
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_NAME: ${{ steps.version.outputs.tag-name }}
         run: |
-          git push --tags
-          echo "tag-name=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          git tag -a "${TAG_NAME}" -m "Version ${VERSION}"
+          git push origin "${TAG_NAME}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
@@ -53,7 +56,7 @@ jobs:
         id: create-release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ steps.push.outputs.tag-name }}
+          tag_name: ${{ steps.version.outputs.tag-name }}
           generate_release_notes: true
       - name: Comment on PRs with link to release they are included in
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          token: ${{ secrets.GH_API_TOKEN }}
       - name: Setup git repo
-        env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
         run: |
           git config user.name $GITHUB_ACTOR
           git config user.email gh-actions-${GITHUB_ACTOR}@github.com

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,8 +8,13 @@
 
 ## Generating
 
-Run `npm run generate`.  This will generate the API client from the latest OpenAPI spec.  Once generated, you should open a PR and merge the changes.
+Run `npm run generate`.  This will generate the API client from the latest OpenAPI spec and bump the package version.  The bump defaults to `minor`; pass `major` or `patch` to change it (`npm run generate -- patch`).  Once generated, you should open a PR and merge the changes.
 
 ## Publishing
 
-Run the "Publish" GitHub Actions workflow.  This workflow will build, version, and publish the client based on the latest code in the `main` branch.  It is expected that re-generating the client based on the latest OpenAPI spec has already been performed and changes committed.
+The version that gets published is whatever `package.json` on the `main` branch says, so publishing is two steps.
+
+1. Merge a PR that sets the new version.  `npm run generate` does this for you.  For a release that does not involve re-generating the client, run `npm version minor --no-git-tag-version` (or `major` / `patch`), which updates both `package.json` and `package-lock.json` without creating a commit or tag.
+2. Run the "Publish" GitHub Actions workflow.  This builds, tests, and publishes that version to npm, then tags the commit and creates a GitHub release.
+
+The workflow never changes the version itself.  If the version in `package.json` has already been released, the workflow fails before publishing anything.

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -1,8 +1,25 @@
-#!/usr/bin/env -S npx ts-node
+#!/usr/bin/env -S npx tsx
 import "jsh";
 import yaml from "js-yaml";
 
+usage(`\
+Usage:
+  ${$0} [version_type]
+
+Example:
+  ${$0} patch
+
+Generates the API client from the latest OpenAPI spec and bumps the package
+version.  version_type is major, minor, or patch and defaults to minor.\
+`);
+
 const openApiSpecFileName = "open_api_spec.yaml";
+
+const versionType = $1 || "minor";
+if (!["major", "minor", "patch"].includes(versionType)) {
+  echo.red(`Invalid version type: ${versionType}`);
+  usage.printAndExit();
+}
 
 echo("Downloading latest YNAB API OpenAPI spec...");
 exec(
@@ -24,5 +41,8 @@ const serverSpecVersion = openApiSpec.info.version;
 const packageFile = JSON.parse(readFile("./package.json"));
 packageFile.description = `Official JavaScript client for the YNAB API. API documentation available at https://api.ynab.com. Generated from server specification version ${serverSpecVersion}`;
 writeFile("./package.json", JSON.stringify(packageFile, null, 2) + "\n");
+
+echo(`Bumping package version (${versionType})...`);
+exec(`npm version ${versionType} --no-git-tag-version`);
 
 echo.green("Success!");


### PR DESCRIPTION
`package.json` on main has drifted behind npm since March. The publish workflow ran `npm version`, which creates a commit, but `git push --tags` only ever pushed the tag. Landing that commit means pushing to main, which the `tier-1-repos` ruleset blocks without a PAT.

The version now comes from `package.json` on main, set by the same PR that regenerates the client. `npm run generate` takes an optional major/minor/patch argument (defaulting to minor) and bumps `package.json` and `package-lock.json` together. Publish only builds, publishes, and tags the commit it checked out, all of which `GITHUB_TOKEN` can do, so `GH_API_TOKEN` can be deleted from repo secrets. The generate script's shebang also moves to `tsx`, which is the runner actually in devDependencies.