### PR TITLE
Limit Dependabot to minor and patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,3 +24,8 @@ updates:
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
Dependabot was opening PRs for major version bumps alongside the minor and patch ones. This restricts it to minor and patch only, so breaking upgrades get taken on deliberately instead of arriving as routine dependency PRs.

An `allow` entry is added to both the `bundler` and `github-actions` configs in `.github/dependabot.yml`:

```yaml
allow:
  - dependency-name: "*"
    update-types:
      - "version-update:semver-minor"
      - "version-update:semver-patch"
```
