### PR TITLE
Return YYYY-MM-DD from getCurrentDateInISOFormat

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export default {
     let isoLocalDateString = new Date(
       currentDate.getTime() - currentDate.getTimezoneOffset() * 60000
     ).toISOString();
-    return isoLocalDateString;
+    return isoLocalDateString.substr(0, 10);
   },
 
   /**

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -15,6 +15,14 @@ describe("utilities", () => {
     });
   });
 
+  describe("getCurrentDateInISOFormat", () => {
+    it("Returns today date as YYYY-MM-DD without a time component", () => {
+      const currentDate = utils.getCurrentDateInISOFormat();
+      expect(currentDate).to.match(/^\d{4}-\d{2}-\d{2}$/);
+      expect(currentDate).to.not.contain("T");
+    });
+  });
+
   describe("convertFromISODateString", () => {
     it("Converts an ISO formatted date string to a JS date object", () => {
       let date = "2015-12-30";


### PR DESCRIPTION
`getCurrentDateInISOFormat` documented `YYYY-MM-DD` but returned a full `toISOString()` timestamp after the local timezone offset adjustment. Creating a transaction with that value produced YNAB API 400: date must be formatted as YYYY-MM-DD.

Keep the existing offset adjustment and return the first 10 characters so the API gets a date-only string in the system timezone. `getCurrentMonthInISOFormat` already sliced the same string and was unaffected.

Credit @dotNomad for the report.

Fixes #216