### PR TITLE
Fix js-yaml import in the generate script

### DIFF
--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npx ts-node
 import "jsh";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const openApiSpecFileName = "open_api_spec.yaml";
 


### PR DESCRIPTION
`npm run generate` is broken on `main`.  js-yaml 5 (#225) removed the default export, so the script throws before it does anything:

```
file:///Users/arturo/Projects/ynab-sdk-js/scripts/generate.mjs:3
import yaml from "js-yaml";
       ^^^^
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

Switching to `import * as yaml from "js-yaml"` fixes it, and the `yaml.load` call stays the same.

It went unnoticed because generate only runs when the API spec changes, and the last run was before the js-yaml bump.
