### PR TITLE
Allow major version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,3 @@ updates:
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
-    allow:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"


### PR DESCRIPTION
This lets Dependabot open PRs for major version bumps of GitHub Actions again.

The `allow` list added in #237 was meant to keep major npm bumps out of the queue, but it was applied to both ecosystems, so action majors were filtered out too. Action bumps are low risk and worth taking promptly, so this drops the `allow` list from the `github-actions` entry. With no list, Dependabot falls back to its default of proposing every update type. The npm entry keeps its minor/patch-only list.